### PR TITLE
fix(researcher): prevent genre-label prose inference; add language-aware market research

### DIFF
--- a/agents/book-architect.md
+++ b/agents/book-architect.md
@@ -245,7 +245,7 @@ Define the narrative voice with precision:
 
 ```markdown
 **Vocabulary level:** [1-10, where 1 = Hemingway, 10 = Nabokov]
-**Sentence rhythm:** [Short/staccato | Mixed/varied | Long/flowing | Fragmented]
+**Sentence rhythm:** [Default register + how it shifts under scene pressure — name a comp title that uses a similar rhythm as anchor]
 **Formality:** [Street | Casual | Conversational | Measured | Formal | Elevated]
 **Humor presence:** [None | Dry/subtle | Frequent | Central]
 **Emotional register:** [Detached | Restrained | Open | Raw]

--- a/agents/book-researcher.md
+++ b/agents/book-researcher.md
@@ -33,6 +33,8 @@ Search for the top 10-15 books in the target genre/niche published in the last 5
 - "goodreads best [genre] [year]"
 - "[genre] books award winners"
 
+**Detect the book's language and origin from the raw idea.** Search primarily in the book's language. If the book is a translation, also search in the original source language. Include local bestseller platforms, literary prizes, and reader communities for the book's market. Distinguish translated foreign fiction from locally-authored literary and popular fiction — they occupy different market segments.
+
 ### Step 2: Pattern Extraction
 
 From the top 10, identify:
@@ -119,6 +121,7 @@ In addition to the market research report, ALWAYS produce `research/bestseller-d
 - Sensory detail: concrete > abstract
 - Vulnerability > competence (especially in opening chapters)
 - Micro-tension: every page needs an internal emotional contradiction
+- Sentence rhythm: [default register + how it shifts with scene pressure — name a comp title that uses a similar rhythm as anchor]
 
 ## Section 3: Emotional Rules
 - 30%+ content about human closeness/intimacy (#1 ML predictor from 20K-novel study)


### PR DESCRIPTION
## What happened

While running the Book Genesis pipeline across multiple projects, I kept seeing the same problem: the generated prose was mechanical and choppy. Sentences were broken into short, isolated fragments even in routine scenes where there was no tension.

Tracing it back revealed a clear cascade:

1. `book-researcher` generated sentence rhythm rules in `bestseller-dna.md` (Section 2) without citing any supporting evidence, inferring them directly from genre or language labels (e.g. "bureaucratic = dry/short", "Vietnamese = short, concrete sentences").
2. `book-architect` carried those rules into `voice-dna.md` by reducing them to a single static `Sentence rhythm` label (e.g. "Short/staccato"), applied uniformly across the entire book.
3. `book-writer` then treated that label as a global writing rule.
4. The result was prose that read more like bullet points than a novel.

Debug runs confirmed that none of the analyzed comp titles supported these rhythm rules. Ironically, the same `bestseller-dna.md` files explicitly warned against "flat, tidy, grammatically correct prose with no soul"—the exact failure these inferred rules produced.

I also found a second issue: regardless of the book's language, `book-researcher` only searched English-language sources, leading to market positioning aimed at the wrong audience.

I validated the complete fix end to end (researcher → architect → writer) on a Vietnamese thriller project. The final output naturally shifted between three distinct cadence modes-mixed procedural, clipped action, and expanded dread-grounded in two comp titles rather than relying on a monotonous short-sentence default.

---

## Changes

### `agents/book-researcher.md`

- Added a `Sentence rhythm` entry to Section 2 of the Bestseller DNA template. Rhythm guidance must now describe the default register and how it changes under scene pressure, and every recommendation must be supported by a named comp title and source.
- Added language detection to Step 1. The agent now detects the book's language and origin from the raw idea, researches primarily in that language, and also searches in the original source language when the project is a translation. It also distinguishes translated fiction from locally authored literary fiction and locally authored commercial/genre fiction.

### `agents/book-architect.md`

- Replaced the static `Sentence rhythm` pick-one field (`[Short/staccato | Mixed/varied | Long/flowing | Fragmented]`) with a prompt requiring the architect to describe the default register and how it shifts with scene pressure, grounded in a comp title. A single static label applied uniformly was the structural mechanism that turned an unsupported researcher inference into book-wide choppy prose.

---

## Test plan

- [ ] Run `book-researcher` on a non-English fiction project and verify it researches in the book's language and distinguishes local market segments.
- [ ] Run `book-researcher` on a translated book and verify it also researches in the original source language.
- [ ] Run `book-researcher` on an English-language fiction project and verify there is no regression.
- [ ] Verify `bestseller-dna.md` Section 2 includes a `Sentence rhythm` entry supported by a named comp title.
- [ ] Verify the `Sentence rhythm` section in `voice-dna.md` describes a dynamic register rather than a single static label.
- [ ] Verify `book-writer` produces distinct sentence cadence across different scene types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for book analysis to better identify a story’s language and origin, including translated works and market context.
  * Refined writing-style guidance to describe sentence rhythm more clearly, including how it changes under pressure and using a comparable title as a reference.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->