### PR TITLE
feat: add portable skill runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,10 @@ This repository contains Book Genesis, an agent-agnostic book-production workflo
 When asked to create, plan, draft, audit, score, revise, or package a book, use the Universal Book Genesis Core unless the user explicitly asks for legacy V4/V5:
 
 ```text
-skills/book-genesis-codex/SKILL.md
+skills/book-genesis/SKILL.md
 ```
 
-The folder name is historical. Treat this as the current universal pipeline for Claude Code, Codex, Antigravity, Kimi, and other file-aware agents.
+Treat this as the current universal pipeline for Claude Code, Codex, Kimi Code, Antigravity, and other file-aware agents. `skills/book-genesis-codex/` remains only as a compatibility package.
 
 When the user asks for bestseller-level, market-ready, agent/editor-ready, or launch-ready work, layer the market umbrella skill on top of the universal core:
 
@@ -27,7 +27,7 @@ skills/book-swarm-panel/SKILL.md
 Load the manifest before advancing phases:
 
 ```text
-skills/book-genesis-codex/references/pipeline/manifest.yaml
+skills/book-genesis/references/pipeline/manifest.yaml
 ```
 
 ## Rules
@@ -43,17 +43,17 @@ skills/book-genesis-codex/references/pipeline/manifest.yaml
 
 ## Agent-Specific Notes
 
-- Claude Code can run `/book-genesis-codex` after installing the full skill folder.
+- Claude Code can run `/book-genesis` after installing the portable suite.
 - Codex can use this repo directly through `AGENTS.md` and the skill folder.
 - Antigravity can use this file as the repo-level playbook.
-- Kimi can use the full skill folder or the active phase prompt plus project state files.
+- Kimi Code can run `/skill:book-genesis` after installing the portable suite.
 - The optional local runner in `runner/cli.py` can scaffold projects and prepare phase packets, but it does not call a model or write literary output.
 
-## Legacy Commands
+## Commands
 
-- `/book-genesis`: V5 Craft Mode legacy orchestrator.
+- `/book-genesis`: canonical portable pipeline.
 - `/book-genesis-full`: full legacy production pipeline.
-- `/book-genesis-codex`: current portable command name kept for compatibility.
+- `/book-genesis-codex`: historical portable command kept for compatibility.
 
 ## Public Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Safe portable installer for Claude Code, Codex, Kimi Code, and shared Agent Skills directories.
+- Distribution manifest, dependency validation, checksums, dry-run, conflict detection, and recoverable forced replacement.
+- Independent evaluator protocol with Grade A/B/C isolation reporting.
+- Blind literary critic role that receives no target score or previous evaluation.
+- Commercial-length fields and Literary Barrier phase in canonical runner state.
+- Portable-suite and installer regression tests.
+
+### Changed
+
+- `skills/book-genesis/` is now canonical universal core.
+- Platform-specific agents consume shared packets and gates instead of redefining editorial logic.
+- Public links now point to `felipelobomotta-blip/book-genesis-v4`.
+- Legacy V4 skills, plus native Claude agents/knowledge, remain opt-in through `--include-legacy`.
+
 ## V4.2 — 2026-06-10
 
 ### Added: Premise Forge (Phase 1.5)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing
+
+Book Genesis accepts improvements to editorial contracts, portable skills, deterministic runner behavior, tests, examples, and documentation.
+
+## Setup
+
+```bash
+git clone https://github.com/felipelobomotta-blip/book-genesis-v4.git
+cd book-genesis-v4
+python runner/cli.py verify-suite
+python -m unittest discover -s tests -v
+```
+
+No provider API key is needed for repository tests. Runner never calls a model.
+
+## Canonical Rules
+
+- `skills/book-genesis/` is canonical portable core.
+- Keep Claude Code, Codex, and Kimi Code on same editorial contracts.
+- Keep platform-specific behavior in installer or dispatch adapters.
+- Never skip adversarial audit before final scoring.
+- Keep raw blind evaluators unaware of target and previous scores.
+- Preserve commercial-length gate and Literary Barrier loop.
+- Do not add literal bestseller guarantees.
+
+## Skill Changes
+
+- Keep `SKILL.md` concise and put detailed contracts under `references/`.
+- Preserve `name` and `description` frontmatter.
+- Add referenced specialist skills to `distribution/portable-suite.json`.
+- Run `python runner/cli.py verify-suite` after changing manifests, registries, prompts, or skill packaging.
+
+## Runner Changes
+
+- Use Python standard library unless dependency earns its installation cost.
+- Add tests for filesystem mutations, failure states, and cross-platform paths.
+- Do not overwrite user-modified skills silently.
+- Keep forced replacement recoverable through backups.
+
+## Pull Requests
+
+Include:
+
+- problem being solved
+- behavioral change
+- affected skills or phases
+- test evidence
+- migration note when file contracts change
+
+Keep manuscripts, API keys, session logs, and private reader data out of commits.

--- a/COWORK-MARKETING.md
+++ b/COWORK-MARKETING.md
@@ -2,7 +2,7 @@
 
 Use this file to seed a cowork session on claude.ai. Paste the relevant section as the task prompt.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 ---
 
@@ -101,7 +101,7 @@ The repo ships the system:
 
 **Tweet 7 (CTA):**
 ```
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 MIT licensed. Built for writers and builders who want a production loop, not a pile of drafts.
 ```
@@ -133,7 +133,7 @@ It works with repo-aware agents like Claude Code, Codex, Kimi, and Antigravity b
 The surprising lesson: the 17-skill version made the books worse. The writer started optimizing for the evaluator. Smaller loop, file-backed state, draft-before-score — that is what worked.
 
 Repo:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 ```
 
 ---
@@ -165,7 +165,7 @@ The surprising lesson: the 17-phase, 19-skill version caught more errors but mad
 
 Proof layer: 10 book projects in under 30 days — memoir, fantasy, thriller, sci-fi, LitRPG, cozy mystery, dark academia. The manuscripts are private; the repo publishes the pipeline, covers/cover concepts, case studies, scoring artifacts, outlines and synopses.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Curious if others building long-form agent workflows have hit the same tradeoff: more orchestration improves consistency but too many live constraints hurt voice.
 ```
@@ -201,7 +201,7 @@ The repo includes public case studies, cover concepts, scoring docs, 9 skills, r
 
 The biggest lesson: fewer live agents worked better. More skills caught more errors, but also made the writing defensive.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Feedback welcome, especially from builders making long-form agent workflows.
 ```
@@ -252,7 +252,7 @@ Before posting anywhere, complete these steps:
 **Product name:** Best Seller Studio
 **Tagline:** Open-source AI book pipeline for Claude Code, Codex, and Kimi
 **Categories:** AI, Open Source, Developer Tools
-**URL:** https://github.com/felipelobomotta-blip/best-seller-studio
+**URL:** https://github.com/felipelobomotta-blip/book-genesis-v4
 
 **Gallery assets (prepare before launch):**
 - `assets/demo.gif` — demo animado

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 # Best Seller Studio
 
-**Turn any idea into a publication-ready book. Fully autonomous. Quality-gated.**
+**Turn any idea into a rigorously built and audited book. Agent-native. Quality-gated.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](LICENSE)
-[![Claude Code](https://img.shields.io/badge/Runs%20on-Claude%20Code-blueviolet?style=flat-square)](https://claude.ai/code)
-[![Quality Gate](https://img.shields.io/badge/Quality%20Gate-8.5%2F10%20enforced-brightgreen?style=flat-square)](#the-quality-gates)
-[![Agents](https://img.shields.io/badge/8%20specialized%20agents-orange?style=flat-square)](#the-agents)
+[![Runtimes](https://img.shields.io/badge/Runs%20on-Claude%20%7C%20Codex%20%7C%20Kimi-blueviolet?style=flat-square)](docs/portability.md)
+[![Quality Gate](https://img.shields.io/badge/Quality%20Gate-calibrated%208.5%2B-brightgreen?style=flat-square)](#quality-gates)
+[![Skills](https://img.shields.io/badge/15%20portable%20skills-orange?style=flat-square)](distribution/portable-suite.json)
 [![Books Shipped](https://img.shields.io/badge/Books%20Shipped-10%2B-blue?style=flat-square)](#proof)
 
-https://github.com/felipelobomotta-blip/best-seller-studio/raw/master/video-demo/out/demo.mp4
+https://github.com/felipelobomotta-blip/book-genesis-v4/raw/master/video-demo/out/demo.mp4
 
 </div>
 
@@ -20,9 +20,9 @@ You have an idea. Maybe it came to you in the shower. Maybe it's been in a note 
 
 Type it in. That's it. The system takes over.
 
-8 AI agents run in sequence — researching your genre, forging a premise with a structural irony engine, writing every chapter, scoring each one independently, revising anything below the quality gate, and packaging the result for publication.
+Portable specialist roles research the genre, forge the premise, build the manuscript, audit it adversarially, revise weak dimensions, score with isolated evaluators, and package the result.
 
-You approve 3 times. Everything else is automatic.
+Important decisions, assumptions, gates, and blockers stay visible in project files. Runtime handles model execution; Book Genesis handles editorial protocol.
 
 **No writing experience required. No prompt engineering. No creative blocks.**
 
@@ -30,39 +30,49 @@ You approve 3 times. Everything else is automatic.
 
 ## Quick start
 
-**Step 1 — Get Claude Code**
+**Step 1 — Choose a runtime**
 
-Download it free at [claude.ai/code](https://claude.ai/code). It runs in your terminal.
+Use Claude Code, Codex, Kimi Code, or another file-aware agent. Install Python 3.10+ for the deterministic runner and installer.
 
-**Step 2 — Install the agents**
+**Step 2 — Clone and verify**
+
+```bash
+git clone https://github.com/felipelobomotta-blip/book-genesis-v4.git
+cd book-genesis-v4
+python runner/cli.py verify-suite
+```
+
+**Step 3 — Install the same portable suite into your runtime**
 
 ```bash
 # macOS / Linux
-git clone https://github.com/felipelobomotta-blip/best-seller-studio
-cp best-seller-studio/agents/*.md ~/.claude/agents/
+bash install.sh claude   # or: codex, kimi, shared
 ```
 
 ```powershell
 # Windows (PowerShell)
-git clone https://github.com/felipelobomotta-blip/best-seller-studio
-Copy-Item best-seller-studio\agents\*.md $env:USERPROFILE\.claude\agents\
+.\install.ps1 -Target codex   # or: claude, kimi, shared
 ```
 
-**Step 3 — Give it an idea**
+The installer performs a conflict check. It never overwrites a modified skill unless you pass `--force` or `-Force`; forced replacements are backed up first.
 
-Open Claude Code and type:
+**Step 4 — Give it an idea**
+
+Invoke `/book-genesis` in Claude Code, use `/skill:book-genesis` in Kimi Code, or ask Codex to use the installed `book-genesis` skill. Then type:
 
 ```
 I have an idea for a book: [your idea here]
 ```
 
-That's it. The `book-orchestrator` agent takes over and runs the whole pipeline.
+The orchestrator creates durable project files and dispatches specialist roles through runtime-native subagents when available.
 
 ---
 
 ## What happens when you run it
 
-Here's the exact sequence:
+Default portable sequence: Intake → Foundation → Architecture → Drafting → Adversarial Audit → Literary Barrier Revision Loop → Final Score → Editorial Package.
+
+The diagram below documents the legacy V4 multi-agent route retained for compatibility:
 
 ```
 ┌─────────────────────────────────────────────────────┐
@@ -149,11 +159,20 @@ Here's the exact sequence:
 
 ---
 
-## The quality gates
+## Quality gates
 
 This is what makes Best Seller Studio different from just asking ChatGPT to write a book.
 
-### Gate 1 — Premise must score 8.0+ before a word is written
+Default portable profile enforces:
+
+1. Product and commercial-length contract before drafting.
+2. Mandatory adversarial audit before scoring.
+3. Literary Barrier revision with blind evaluator reports and recorded independence grade.
+4. Final floor score, weighted score, evidence, and package gates.
+
+The detailed chapter-by-chapter gates below document legacy V4 behavior. Install them only with `--include-legacy`.
+
+### Legacy Gate 1 — Premise must score 8.0+ before a word is written
 
 Every bestseller has the same structural DNA: a contradiction that generates conflict automatically. Gone Girl works because the "perfect marriage" premise immediately contradicts itself. Breaking Bad works because "chemistry teacher becomes drug lord" is a contradiction that escalates by its own logic.
 
@@ -172,7 +191,7 @@ The Premise Forge scores your idea across 6 dimensions:
 
 Your raw idea is always Variant 1 (scored honestly as a baseline). If it already hits 8.0, it wins — the system doesn't forge for the sake of forging. Variants 2–5 are alternatives using different irony engines.
 
-### Gate 2 — Every chapter scores 8.5+ before the manuscript advances
+### Legacy Gate 2 — Every chapter scores 8.5+ before the manuscript advances
 
 The evaluator that scores your chapters is a **separate agent that never wrote any of them**. No self-grading.
 
@@ -186,7 +205,7 @@ Chapters between the hard floor and the 8.5 target enter the **Polish Loop**: th
 
 Anti-inflation protection: each cycle can only add +0.5 maximum. You can't shortcut the gate.
 
-### Gate 3 — All chapters 8.5+ AND CVI-Launch ≥ 9.0
+### Legacy Gate 3 — All chapters 8.5+ AND CVI-Launch ≥ 9.0
 
 CVI-Launch is our best-seller potential proxy. 9.0 is "breakout potential, Gone Girl tier" — the manuscript has a word-of-mouth mechanism built in structurally, not just good prose.
 
@@ -194,7 +213,9 @@ The manuscript only reaches packaging when both gates pass.
 
 ---
 
-## The agents
+## Portable roles and legacy Claude agents
+
+Portable profile owns specialist behavior through [`agent-registry.yaml`](skills/book-bestseller-studio/references/agent-registry.yaml) and fresh agent packets. Table below documents native Claude V4 profiles retained for compatibility.
 
 | Agent | Role |
 |---|---|
@@ -226,34 +247,34 @@ These ideas were run through the pipeline:
 
 ---
 
-## Cost
+## Inference and cost
 
-Using **Claude Sonnet 4.6** (recommended):
+Book Genesis does not host a model and does not call a provider API. The selected runtime owns inference, authentication, quotas, and billing.
 
-| What | Cost |
-|---|---|
-| Full book, 20 chapters | ~$20–30 |
-| Per chapter (avg 1.5 polish cycles) | ~$1.00–1.50 |
-| Setup phases (research + forge + foundation) | ~$1.50 |
+- Claude Code uses the user's Claude account or configured provider.
+- Codex uses the user's Codex/OpenAI environment.
+- Kimi Code uses the user's Kimi membership or configured provider.
+- Local or shared Agent Skills directories remain possible through the `shared` target.
 
-Claude Code runs on your Anthropic account via OAuth — no separate API key needed.
+No central Book Genesis API bill exists. Runtime limits still apply.
 
 ---
 
 ## Requirements
 
-- [Claude Code](https://claude.ai/code) — log in with your Anthropic account (OAuth). No API key needed.
-- ~30 minutes unattended runtime per book (the pipeline runs autonomously)
+- Python 3.10+
+- Claude Code, Codex, Kimi Code, or another agent that can read and write project files
+- enough runtime quota and context for long-form work
 
 ---
 
 ## Honest caveats
 
-**What the system guarantees:** The manuscript scores 8.5+ on the internal quality gate before leaving the pipeline. No chapter ships silently below target. Every gate failure is surfaced to you explicitly.
+**What the system guarantees:** The workflow does not approve a manuscript unless required artifacts and documented quality gates pass. Failures and degraded evaluator independence are surfaced explicitly. The mechanical runner validates contracts, not literary truth.
 
 **What the system does not guarantee:** A literal bestseller. Cover design, marketing, timing, and luck are outside the manuscript and outside this system. The quality gate attacks the word-of-mouth mechanism (retellability + CVI) because that's the lever we actually control.
 
-**About the 8.5 score:** It's an internally-calibrated ruler based on comps that hit bestseller lists — not a certified external measurement. It's the best proxy we can build before a real audience reads the book.
+**About the 8.5 score:** It is an internal editorial ruler, not certified external measurement. Final reports record evaluator isolation Grade A, B, or C; Grade C cannot support an independent-quality claim.
 
 ---
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -39,7 +39,7 @@ Steps to cut a new version of Best Seller Studio. Copy this into a GitHub Issue 
 ## Post-release
 
 - [ ] Pin release on GitHub
-- [ ] Post release announcement in [Discussions](https://github.com/felipelobomotta-blip/best-seller-studio/discussions/categories/announcements) (if category exists)
+- [ ] Post release announcement in [Discussions](https://github.com/felipelobomotta-blip/book-genesis-v4/discussions/categories/announcements) (if category exists)
 - [ ] Update social preview banner if the version number is on it
 - [ ] Twitter/X + LinkedIn post linking the release
 - [ ] Show HN or Reddit r/ClaudeAI post if the release is significant (major features, not patch)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ Best Seller Studio uses `MAJOR.MINOR` versioning. Security fixes are applied to 
 
 If you find a vulnerability — in the agent prompts, the install scripts, the file I/O contracts, or anywhere else in the pipeline that could compromise a user's system, credentials, or work — please report it privately:
 
-1. Open a private [GitHub Security Advisory](https://github.com/felipelobomotta-blip/best-seller-studio/security/advisories/new), OR
+1. Open a private [GitHub Security Advisory](https://github.com/felipelobomotta-blip/book-genesis-v4/security/advisories/new), OR
 2. Message the maintainer through the email on the GitHub profile.
 
 **What to include:**

--- a/assets/social/card-pipeline.svg
+++ b/assets/social/card-pipeline.svg
@@ -79,6 +79,6 @@
   <!-- Footer -->
   <line x1="380" y1="950" x2="700" y2="950" stroke="#D4A574" stroke-opacity="0.4" stroke-width="1"/>
   <text x="540" y="990" font-family="Inter, Helvetica, sans-serif" font-size="18" letter-spacing="6" text-anchor="middle" fill="#D4A574">
-    BOOK GENESIS · github.com/felipelobomotta-blip/best-seller-studio
+    BOOK GENESIS · github.com/felipelobomotta-blip/book-genesis-v4
   </text>
 </svg>

--- a/assets/social/videos/generate_tutorial_2026-05-25.py
+++ b/assets/social/videos/generate_tutorial_2026-05-25.py
@@ -185,7 +185,7 @@ T={
         ('out','done. a book package you can audit.')],
   'cta_pre':"BOOK GENESIS",
   'cta1':"Open source. Runs on any agent\nthat reads files.",
-  'url':"github.com/felipelobomotta-blip/best-seller-studio",
+  'url':"github.com/felipelobomotta-blip/book-genesis-v4",
   'cta_sub':"MIT - Claude Code - Codex - Kimi - Antigravity",
  },
  'pt':{
@@ -228,7 +228,7 @@ T={
         ('out','pronto. um pacote de livro auditavel.')],
   'cta_pre':"BOOK GENESIS",
   'cta1':"Open source. Roda em qualquer agente\nque le arquivo.",
-  'url':"github.com/felipelobomotta-blip/best-seller-studio",
+  'url':"github.com/felipelobomotta-blip/book-genesis-v4",
   'cta_sub':"MIT - Claude Code - Codex - Kimi - Antigravity",
  },
 }

--- a/assets/social/videos/generate_video_2026-05-25_19x.py
+++ b/assets/social/videos/generate_video_2026-05-25_19x.py
@@ -101,7 +101,7 @@ T = {
   'lesson3':"wins from decomposition.",
   'cta_pre':"BOOK GENESIS",
   'cta1':"Open source. Runs on any agent\nthat reads files.",
-  'url':"github.com/felipelobomotta-blip/best-seller-studio",
+  'url':"github.com/felipelobomotta-blip/book-genesis-v4",
   'cta_sub':"MIT · Claude Code · Codex · Kimi · Antigravity",
  },
  'pt':{
@@ -125,7 +125,7 @@ T = {
   'lesson3':"ganha com decomposição.",
   'cta_pre':"BOOK GENESIS",
   'cta1':"Open source. Roda em qualquer agente\nque lê arquivo.",
-  'url':"github.com/felipelobomotta-blip/best-seller-studio",
+  'url':"github.com/felipelobomotta-blip/book-genesis-v4",
   'cta_sub':"MIT · Claude Code · Codex · Kimi · Antigravity",
  }
 }

--- a/distribution/portable-suite.json
+++ b/distribution/portable-suite.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "suite_name": "book-genesis-portable",
+  "canonical_skill": "book-genesis",
+  "agent_registry": "skills/book-bestseller-studio/references/agent-registry.yaml",
+  "skills": [
+    "beta-reader",
+    "book-bestseller-studio",
+    "book-editor",
+    "book-genesis",
+    "book-researcher",
+    "book-swarm-panel",
+    "copy-editing",
+    "editorial-package",
+    "humanizer",
+    "literary-agent-panel",
+    "manuscript-manager",
+    "narrative-foundation",
+    "production-prep",
+    "prose-craft",
+    "series-architect"
+  ],
+  "legacy_skills": [
+    "book-genesis-codex",
+    "book-genesis-full"
+  ],
+  "legacy_claude": {
+    "agents_dir": "agents",
+    "knowledge_dir": "knowledge"
+  },
+  "targets": {
+    "claude": {
+      "home_env": "CLAUDE_CONFIG_DIR",
+      "default_home": ".claude",
+      "skills_dir": "skills"
+    },
+    "codex": {
+      "home_env": "CODEX_HOME",
+      "default_home": ".codex",
+      "skills_dir": "skills"
+    },
+    "kimi": {
+      "home_env": "KIMI_CODE_HOME",
+      "default_home": ".kimi-code",
+      "skills_dir": "skills"
+    },
+    "shared": {
+      "home_env": "",
+      "default_home": ".agents",
+      "skills_dir": "skills"
+    }
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture -- Book Genesis V4
 
-> Current note: the default workflow for new projects is now the Universal Book Genesis Core (`skills/book-genesis-codex/`). This document remains the legacy V4/V5 architecture reference. See `docs/book-genesis-codex.md` for the portable agent pipeline.
+> Current note: the default workflow for new projects is now the Universal Book Genesis Core (`skills/book-genesis/`). This document remains the legacy V4/V5 architecture reference. See `docs/book-genesis-codex.md` for the portable agent pipeline.
 
 Book Genesis V4.1 is a 17-phase pipeline (with sub-phases) that transforms a one-sentence idea into a commercially viable, publishable manuscript. V4 was built from the ground up after a 5-genre stress test (SYSTEM-ANALYSIS.md) identified 9 structural problems in V2. V4.1 adds 8 skills, doubles the phase count, and introduces fully autonomous execution via `/book-auto`. Every architectural change traces back to a specific failure in the system analysis or lessons learned from real manuscript iterations.
 

--- a/docs/book-genesis-codex.md
+++ b/docs/book-genesis-codex.md
@@ -2,10 +2,10 @@
 
 The Universal Book Genesis Core is the portable, reduced-pressure version of Book Genesis. It works in Claude Code, Codex, Antigravity, Kimi, and other agents that can read files and maintain project state.
 
-The implementation lives at:
+Canonical implementation lives at:
 
 ```text
-skills/book-genesis-codex/
+skills/book-genesis/
   SKILL.md
   agents/openai.yaml
   references/
@@ -13,6 +13,7 @@ skills/book-genesis-codex/
     pipeline/phases.md
     prompts/
     scoring/genesis-score-codex.md
+    scoring/evaluator-protocol.md
     legacy-v4-book-genesis.md
 ```
 
@@ -28,7 +29,7 @@ tests/
 
 The runner scaffolds projects, prepares phase packets, validates required files, advances gates, prepares optional Book Swarm Panel/MiroFish bridge folders, and writes specialist agent packets for Book Bestseller Studio. It does not call a model or generate real prose.
 
-The folder name `book-genesis-codex` is historical and preserved so existing commands and installs keep working. The product positioning is broader: **Book Genesis is a universal book pipeline for AI agents.**
+The folder `book-genesis-codex` is historical and preserved for compatibility. New installs use `book-genesis`: **Book Genesis is a universal book pipeline for AI agents.**
 
 ## Why It Exists
 
@@ -48,10 +49,10 @@ The universal core makes a different bet:
 
 | Agent | Status | Notes |
 |-------|--------|-------|
-| Claude Code | Native skill | Install the full folder and run `/book-genesis-codex` |
-| Codex | Native repo workflow | Use `AGENTS.md` or the skill folder directly |
+| Claude Code | Native skill | Install portable suite and run `/book-genesis` |
+| Codex | Native skill/repo workflow | Install portable suite or use `AGENTS.md` |
 | Antigravity | Agent playbook | Open the repo and follow `AGENTS.md` |
-| Kimi | File-backed workflow | Provide the skill folder or paste the active phase contract |
+| Kimi Code | Native Agent Skill | Install portable suite and run `/skill:book-genesis` |
 | Generic coding agents | Portable | Must read files, write artifacts, and update state |
 
 ## Canonical Pipeline
@@ -63,8 +64,9 @@ The universal core makes a different bet:
 | 2 | Architecture | outline, tension map, opening strategy |
 | 3 | Drafting | chapter files in `manuscript/chapters/` |
 | 4 | Adversarial Audit | structural criticism before score |
-| 5 | Final Score | Genesis Score report |
-| 6 | Editorial Package | logline, blurb, synopsis, cover brief, query strategy |
+| 5 | Literary Barrier Revision Loop | isolated evaluation and evidence-backed revision |
+| 6 | Final Score | Genesis Score report |
+| 7 | Editorial Package | logline, blurb, synopsis, cover brief, query strategy |
 
 Default project tree:
 
@@ -100,6 +102,7 @@ Approval requires:
 - no dimension below 8.0
 - evidence for every dimension
 - adversarial audit not marked `MAJOR REWRITE`
+- evaluator independence grade recorded
 
 The floor principle remains the most important rule: the manuscript is only as strong as its weakest major dimension.
 
@@ -131,13 +134,13 @@ The remaining risk is not technical. It is editorial: any AI writing system can 
 For Claude Code:
 
 ```text
-/book-genesis-codex pt-br "memoir sobre burnout e reconstrucao profissional"
+/book-genesis pt-br "memoir sobre burnout e reconstrucao profissional"
 ```
 
 For Codex, Antigravity, Kimi, or another repo-aware agent:
 
 ```text
-Use Book Genesis. Read AGENTS.md, then run the manifest in skills/book-genesis-codex/references/pipeline/manifest.yaml one phase at a time.
+Use Book Genesis. Read AGENTS.md, then run the manifest in skills/book-genesis/references/pipeline/manifest.yaml one phase at a time.
 ```
 
 For a local mechanical check:
@@ -161,4 +164,4 @@ For packaging only:
 Use Book Genesis to create the editorial package from this approved manuscript.
 ```
 
-Use the old `/book-genesis` or `/book-genesis-full` only when you explicitly want the legacy Claude Code pipeline.
+Use `/book-genesis-full` or the compatibility `/book-genesis-codex` only when you explicitly want an older package.

--- a/docs/distribution-kit.md
+++ b/docs/distribution-kit.md
@@ -2,7 +2,7 @@
 
 Public launch kit for the English-first GitHub repo.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Primary positioning:
 
@@ -112,7 +112,7 @@ The repo ships the system:
 
 ```text
 Repo:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 
 MIT licensed. Built for writers and builders who want a production loop, not a pile of drafts.
 ```
@@ -138,7 +138,7 @@ research, book architecture, developmental editing, literary-agent panel, MiroFi
 It works with repo-aware agents like Claude Code, Codex, Kimi, and Antigravity because it is just files: markdown instructions, scoring contracts, manifests, and durable project state.
 
 Repo:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 ```
 
 ## Hacker News

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
 # FAQ -- Book Genesis
 
-> Current note: the default workflow for new projects is the Universal Book Genesis Core in `skills/book-genesis-codex/`. The folder name is historical; the workflow is designed for Claude Code, Codex, Antigravity, Kimi, and other file-aware agents. The older V4/V5 answers below are kept for historical and legacy Claude Code usage.
+> Current note: the default workflow for new projects is the Universal Book Genesis Core in `skills/book-genesis/`. The workflow is designed for Claude Code, Codex, Kimi Code, Antigravity, and other file-aware agents. Older V4/V5 answers below remain for historical and legacy Claude Code usage.
 
 ---
 
@@ -8,7 +8,7 @@
 
 ### What is Book Genesis?
 
-Book Genesis is a file-backed book production system. The current universal core is `book-genesis-codex`, a portable 7-phase pipeline for Claude Code, Codex, Antigravity, Kimi, and generic agent IDEs. The repository also preserves the older V4/V5 Claude Code skill network: 17 phases, specialized skills, Genesis Score, commercial viability prediction, anti-AI pattern checks, and automated revision loops.
+Book Genesis is a file-backed book production system. The current universal core is `book-genesis`, a portable 8-phase pipeline for Claude Code, Codex, Kimi Code, Antigravity, and generic agent IDEs. The repository also preserves older V4/V5 compatibility packages, specialized skills, Genesis Score, anti-AI pattern checks, and revision loops.
 
 For the current architecture, start with `docs/book-genesis-codex.md`.
 

--- a/docs/i18n-guide.md
+++ b/docs/i18n-guide.md
@@ -70,7 +70,7 @@ The pipeline is currently left-to-right only. Arabic, Hebrew, Persian would need
 2. RTL-aware demo assets (currently LTR-only)
 3. Native reviewer for the evaluator's phonetic/rhythm rules (very different from LTR languages)
 
-We welcome a PR that opens this direction. Talk to us in [Discussions](https://github.com/felipelobomotta-blip/best-seller-studio/discussions) first — the design work is bigger than the PR.
+We welcome a PR that opens this direction. Talk to us in [Discussions](https://github.com/felipelobomotta-blip/book-genesis-v4/discussions) first — the design work is bigger than the PR.
 
 ## Encoding
 

--- a/docs/international-social-campaign.md
+++ b/docs/international-social-campaign.md
@@ -5,7 +5,7 @@ Goal: position Book Genesis as an open-source AI book studio for global builders
 Repo:
 
 ```text
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 ```
 
 Core positioning:
@@ -118,7 +118,7 @@ Post 6:
 
 ```text
 Repo:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 
 MIT licensed. Feedback welcome from writers, agent builders, publishing-tech teams, and long-form workflow nerds.
 ```

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -1,135 +1,94 @@
 # Portability
 
-Book Genesis is agent-agnostic by design. It is a folder of markdown instructions, phase prompts, manifests, scoring rules, and file contracts. Any agent that can read files and write project artifacts can run it.
+Book Genesis is an Agent Skills package, not a hosted model wrapper. Claude Code, Codex, and Kimi Code install the same canonical skill folders and execute them with their own accounts, models, permissions, and quotas.
 
-The repository has two layers:
+## Canonical Package
 
-1. The **Universal Book Genesis Core** in `skills/book-genesis-codex/`.
-2. The legacy Claude Code system in `skills/`, `agents/`, and `knowledge/`.
+`skills/book-genesis/` is the universal core. `distribution/portable-suite.json` lists every skill required by the portable Bestseller Studio profile. Specialist agent ownership lives in `skills/book-bestseller-studio/references/agent-registry.yaml`.
 
-The `book-genesis-codex` folder name is historical and kept for compatibility. It does not mean the pipeline only works in Codex.
+`skills/book-genesis-codex/` and `skills/book-genesis-full/` remain compatibility packages. They are excluded from default portable installs.
 
-## Minimum Portable Package
+Do not copy only `SKILL.md`. Phase prompts, scoring rules, and evaluator protocol live under `references/`.
 
-Minimum:
-
-```text
-skills/book-genesis-codex/
-```
-
-Recommended:
-
-```text
-AGENTS.md
-skills/book-genesis-codex/
-docs/book-genesis-codex.md
-docs/portability.md
-docs/book-gallery.md
-examples/cases/
-assets/covers/
-```
-
-Do not copy only `SKILL.md`; the skill will lose the phase prompts, manifest, orchestration rules, and scoring contract.
-
-## Claude Code
-
-Claude Code supports multi-file skills with `SKILL.md` plus supporting resources. Install with:
+## Verify Before Installing
 
 ```bash
-./install.sh
+python runner/cli.py verify-suite
 ```
 
-or on Windows:
+Validation checks skill frontmatter, dependency closure, phase prompts, mandatory adversarial audit, Literary Barrier loop, evaluator protocol, and target definitions.
+
+## Runtime Installers
+
+macOS/Linux:
+
+```bash
+bash install.sh claude
+bash install.sh codex
+bash install.sh kimi
+bash install.sh shared
+```
+
+Windows PowerShell:
 
 ```powershell
-.\install.ps1
+.\install.ps1 -Target claude
+.\install.ps1 -Target codex
+.\install.ps1 -Target kimi
+.\install.ps1 -Target shared
 ```
 
-The installer copies the full skill folders into `~/.claude/skills/`, including `references/`.
+Default user locations:
 
-Invocation:
+| Target | Skills directory | Invocation |
+|---|---|---|
+| Claude Code | `~/.claude/skills/` | `/book-genesis` |
+| Codex | `$CODEX_HOME/skills/` or `~/.codex/skills/` | ask Codex to use `book-genesis` |
+| Kimi Code | `$KIMI_CODE_HOME/skills/` or `~/.kimi-code/skills/` | `/skill:book-genesis` |
+| Shared | `~/.agents/skills/` | runtime-dependent |
+
+Use `--dest PATH` with the Python command for an isolated or project-specific skills directory:
+
+```bash
+python runner/cli.py install kimi --dest ./sandbox/skills --dry-run
+```
+
+## Conflict Safety
+
+- unchanged skills are skipped
+- changed destination skills block installation by default
+- `--force` or `-Force` moves changed skills into `.book-genesis-backups/<timestamp>/` before replacement
+- `.book-genesis-install.json` records installed skill checksums
+- `--include-legacy` adds compatibility skills; for Claude it also installs native V4 agents and knowledge files. Default remains portable-only.
+
+## Agent Dispatch
+
+Portable agents are roles, packets, and gates rather than duplicated platform prompts.
+
+```bash
+python runner/cli.py prepare-agent-packet my-book prose_writer
+python runner/cli.py prepare-agent-packet my-book adversarial_auditor
+python runner/cli.py prepare-agent-packet my-book scorekeeper
+```
+
+Give each packet to a fresh runtime-native subagent. Claude Code may use custom or general-purpose subagents, Codex may dispatch isolated subagents, and Kimi Code may dispatch its built-in subagents. When isolation is unavailable, run roles sequentially and record Evaluation Independence Grade C.
+
+## Generic Agents
+
+Minimum runtime capabilities:
+
+- read a directory of Markdown files
+- follow YAML phase manifest
+- create and update project files
+- preserve state across turns
+- isolate drafting, revision, and evaluation when possible
+
+Generic instruction:
 
 ```text
-/book-genesis-codex
+Run Book Genesis as a file-backed book-production pipeline. Read AGENTS.md and skills/book-genesis/SKILL.md. Follow skills/book-genesis/references/pipeline/manifest.yaml exactly. Load only the active phase prompt. Persist decisions to files. Never score before adversarial audit. Apply the independent evaluator protocol before any final quality claim.
 ```
 
-The older commands remain available:
+## Runtime Boundary
 
-- `/book-genesis` for the V5 Craft Mode orchestrator
-- `/book-genesis-full` for the full V4/V5 production pipeline
-
-## Codex
-
-Codex can use the core directly from the repo or from Felipe's local skill directory. The important part is that the whole folder is available, not just `SKILL.md`, because the phase prompts live under `references/`.
-
-Expected behavior:
-
-- load `AGENTS.md` or `skills/book-genesis-codex/SKILL.md`
-- read `references/pipeline/manifest.yaml`
-- load only the active phase prompt
-- write project state and artifacts to files
-- update `PROJECT_STATE.yaml` after every phase or chapter block
-
-## Antigravity
-
-Antigravity-style IDEs do not need native skill support. Open the repository and tell the agent:
-
-```text
-Use Book Genesis. Follow AGENTS.md and the phase order in skills/book-genesis-codex/references/pipeline/manifest.yaml.
-Persist every important decision to files.
-Only load the active phase prompt.
-Do not skip adversarial audit.
-```
-
-If the agent asks for the relevant files, provide:
-
-```text
-AGENTS.md
-skills/book-genesis-codex/SKILL.md
-skills/book-genesis-codex/references/pipeline/manifest.yaml
-```
-
-## Kimi
-
-Kimi can run Book Genesis as a file-backed playbook. Use the same package:
-
-```text
-skills/book-genesis-codex/
-```
-
-Then give this instruction:
-
-```text
-You are running Book Genesis. Read SKILL.md, then follow the manifest one phase at a time. Create PROJECT_STATE.yaml and ASSUMPTIONS.md. Write artifacts to files. Audit before scoring.
-```
-
-If Kimi is being used in a chat-only context, paste `AGENTS.md`, `SKILL.md`, and the active phase prompt. For serious book work, keep a project folder and update the files between turns.
-
-## Other Agents
-
-The minimum requirements are:
-
-- can read a folder of markdown files
-- can follow a YAML or markdown phase manifest
-- can create and update files
-- can keep project state across turns
-- can separate drafting, audit, scoring, and packaging
-
-Use this generic instruction:
-
-```text
-Run Book Genesis as a file-backed book production pipeline. Read AGENTS.md first. Use skills/book-genesis-codex/SKILL.md as the operating loop. Follow the manifest exactly. Load only the active phase prompt. Persist decisions to files. Never score before adversarial audit.
-```
-
-## Why It Ports Cleanly
-
-Book Genesis avoids tool-specific dependencies:
-
-- no external API is required
-- no database is required
-- no build step is required
-- prompts are plain markdown
-- project state is plain YAML/markdown
-- quality control is defined as written contracts, not hidden runtime logic
-
-That is why the same core can work in Claude Code, Codex, Antigravity, Kimi, and most capable coding agents.
+Runner scaffolds projects, validates files, prepares phase packets, advances mechanical gates, and prepares specialist packets. It never calls a model, writes literary prose, or certifies literary quality. Runtime performs creative and critical work using user's own account.

--- a/docs/reddit-launch-kit.md
+++ b/docs/reddit-launch-kit.md
@@ -66,12 +66,12 @@ The repo now includes:
 - portability notes for Claude Code, Codex, Antigravity, Kimi, and generic agents
 
 Repo:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 
 The most interesting files:
 
 - docs/book-gallery.md
-- skills/book-genesis-codex/
+- skills/book-genesis/
 - docs/portability.md
 - docs/book-genesis-codex.md
 - SHOWCASE.md
@@ -123,7 +123,7 @@ So I rebuilt it as a smaller universal core:
 
 ```text
 Repo:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 
 The proof layer:
 10+ book projects, covers/cover concepts, case studies, scoring artifacts, and the portable skill.
@@ -145,11 +145,11 @@ The surprising part was that the larger version of the system - 17 phases, 19 sk
 The current version is smaller and agent-agnostic: durable project files, one active phase prompt at a time, adversarial audit before scoring, and an editorial package after the manuscript survives critique. It can run in Claude Code, Codex, Antigravity, Kimi, or any agent that can read and write files.
 
 Repo:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Useful files:
 - docs/book-gallery.md
-- skills/book-genesis-codex/
+- skills/book-genesis/
 - docs/portability.md
 - docs/book-genesis-codex.md
 - SHOWCASE.md

--- a/docs/reddit-posts-bg-launch.md
+++ b/docs/reddit-posts-bg-launch.md
@@ -2,7 +2,7 @@
 
 Four English launch posts with different angles. Stagger them. Do not cross-post identical copy.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 ## 1. r/ClaudeAI
 
@@ -29,7 +29,7 @@ Everything persists to files: `PROJECT_STATE.yaml`, `ASSUMPTIONS.md`, `manuscrip
 
 The goal is not "AI writes a book in one shot." The goal is a repeatable production loop with evidence, gates, and revision pressure.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Curious how others are structuring multi-skill Claude Code workflows.
 
@@ -57,7 +57,7 @@ Book Genesis is the open-source version. It is markdown-first and agent-agnostic
 
 The repo includes public case studies, cover concepts, scoring docs, skills, runner scripts, and launch materials. Manuscripts stay private.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Feedback welcome, especially from builders making long-form agent workflows.
 
@@ -84,7 +84,7 @@ Key design choice: adversarial audit happens before the quantitative score. The 
 
 The current repo also includes a 9-skill book studio: researcher, editor, agent panel, reader swarm, copyeditor, humanizer, and editorial packager.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Interested in whether this pattern generalizes beyond fiction: courses, reports, research briefs, grants, game narratives, etc.
 
@@ -106,7 +106,7 @@ Book Genesis is the open-source version of that workflow. It runs as a file-back
 
 It also includes a simulated agent/editor panel and reader-swarm diagnostics, but those are decision aids, not replacements for human readers.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 I would especially appreciate feedback from writers on what the audit phase should catch before a score is allowed.
 

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -22,7 +22,7 @@ python runner/cli.py prepare-agent-packet my-book prose_writer
 my-book/work/current-phase.md
 ```
 
-That file contains the phase label, gate, required outputs, and the full active phase prompt from `skills/book-genesis-codex/references/`.
+That file contains the phase label, gate, required outputs, and the full active phase prompt from `skills/book-genesis/references/`.
 
 `prepare-swarm` writes:
 

--- a/docs/skills-reference.md
+++ b/docs/skills-reference.md
@@ -1,6 +1,6 @@
 # Skills Reference -- Book Genesis V4
 
-> Current note: this is the legacy V4/V5 skill reference. For the portable agent-agnostic core, see `skills/book-genesis-codex/` and `docs/book-genesis-codex.md`.
+> Current note: this is the legacy V4/V5 skill reference. For the portable agent-agnostic core, see `skills/book-genesis/` and `docs/book-genesis-codex.md`.
 
 Market-level add-ons live beside the universal core. The current public positioning is the **Book Genesis Bestseller Skills Suite**:
 

--- a/docs/v5-philosophy.md
+++ b/docs/v5-philosophy.md
@@ -1,6 +1,6 @@
 # Genesis V5 Philosophy -- Why Fewer Skills Produce Better Books
 
-> Current note: this philosophy directly informed the Universal Book Genesis Core in `skills/book-genesis-codex/`. The current workflow keeps the "fewer active constraints while drafting" lesson and makes it portable across Claude Code, Codex, Antigravity, Kimi, and other agent tools.
+> Current note: this philosophy directly informed the Universal Book Genesis Core in `skills/book-genesis/`. The current workflow keeps the "fewer active constraints while drafting" lesson and makes it portable across Claude Code, Codex, Kimi Code, Antigravity, and other agent tools.
 
 ## The Data
 

--- a/docs/viral-launch-tasks.md
+++ b/docs/viral-launch-tasks.md
@@ -235,7 +235,7 @@ The counterintuitive part: the larger 17-phase / 19-skill version made the books
 
 The current version is smaller, agent-agnostic, and works with Claude Code, Codex, Antigravity, Kimi, or any agent that can read/write files.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 Proof layer: docs/book-gallery.md
 ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,76 +1,40 @@
-# Book Genesis installer for Windows PowerShell.
-# Installs full skill folders, including supporting references, to ~/.claude/.
+[CmdletBinding()]
+param(
+    [ValidateSet("claude", "codex", "kimi", "shared")]
+    [string]$Target = "claude",
+    [string]$Destination = "",
+    [switch]$Force,
+    [switch]$DryRun,
+    [switch]$IncludeLegacy
+)
 
 $ErrorActionPreference = "Stop"
+$repoDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$cliPath = Join-Path $repoDir "runner\cli.py"
 
-$RepoDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-if (-not $RepoDir) { $RepoDir = Get-Location }
-
-$SkillsDir = Join-Path $RepoDir "skills"
-$KnowledgeDir = Join-Path $RepoDir "knowledge"
-$AgentsDir = Join-Path $RepoDir "agents"
-$TargetSkills = Join-Path $env:USERPROFILE ".claude\skills"
-$TargetKnowledge = Join-Path $env:USERPROFILE ".claude\knowledge"
-$TargetAgents = Join-Path $env:USERPROFILE ".claude\agents"
-
-Write-Host ""
-Write-Host "Book Genesis" -ForegroundColor Blue
-Write-Host "V4/V5 legacy system + portable Codex edition" -ForegroundColor Yellow
-Write-Host ""
-Write-Host "Installing skills, supporting references, agents, and knowledge base" -ForegroundColor Yellow
-Write-Host ""
-
-if (-not (Test-Path $SkillsDir)) {
-    Write-Host "Error: skills\ directory not found. Run this script from the repository root." -ForegroundColor Red
-    exit 1
+$pythonCommand = Get-Command python -ErrorAction SilentlyContinue
+$launcherArgs = @()
+if (-not $pythonCommand) {
+    $pythonCommand = Get-Command py -ErrorAction SilentlyContinue
+    $launcherArgs = @("-3")
+}
+if (-not $pythonCommand) {
+    throw "Python 3 was not found in PATH."
 }
 
-foreach ($dir in @($TargetSkills, $TargetKnowledge, $TargetAgents)) {
-    if (-not (Test-Path $dir)) {
-        New-Item -ItemType Directory -Path $dir -Force | Out-Null
-    }
+$cliArgs = @($cliPath, "install", $Target)
+if ($Destination) {
+    $cliArgs += @("--dest", $Destination)
+}
+if ($Force) {
+    $cliArgs += "--force"
+}
+if ($DryRun) {
+    $cliArgs += "--dry-run"
+}
+if ($IncludeLegacy) {
+    $cliArgs += "--include-legacy"
 }
 
-$count = 0
-Get-ChildItem -Path $SkillsDir -Directory | ForEach-Object {
-    $skillName = $_.Name
-    $skillFile = Join-Path $_.FullName "SKILL.md"
-    if (Test-Path $skillFile) {
-        $destDir = Join-Path $TargetSkills $skillName
-        if (Test-Path $destDir) {
-            Remove-Item -LiteralPath $destDir -Recurse -Force
-        }
-        New-Item -ItemType Directory -Path $destDir -Force | Out-Null
-        Copy-Item -Path (Join-Path $_.FullName "*") -Destination $destDir -Recurse -Force
-        Write-Host "  + $skillName" -ForegroundColor Green
-        $count++
-    }
-}
-
-$kbCount = 0
-if (Test-Path $KnowledgeDir) {
-    Get-ChildItem -Path $KnowledgeDir -Filter "*.md" | ForEach-Object {
-        Copy-Item $_.FullName (Join-Path $TargetKnowledge $_.Name) -Force
-        Write-Host "  + knowledge/$($_.Name)" -ForegroundColor Green
-        $kbCount++
-    }
-}
-
-$agentCount = 0
-if (Test-Path $AgentsDir) {
-    Get-ChildItem -Path $AgentsDir -Filter "*.md" | ForEach-Object {
-        Copy-Item $_.FullName (Join-Path $TargetAgents $_.Name) -Force
-        Write-Host "  + agent/$($_.Name)" -ForegroundColor Green
-        $agentCount++
-    }
-}
-
-Write-Host ""
-Write-Host "Done. $count skills + $agentCount agents + $kbCount knowledge files installed" -ForegroundColor Green
-Write-Host ""
-Write-Host "Skills:    $TargetSkills" -ForegroundColor Blue
-Write-Host "Agents:    $TargetAgents" -ForegroundColor Blue
-Write-Host "Knowledge: $TargetKnowledge" -ForegroundColor Blue
-Write-Host ""
-Write-Host "Open Claude Code and type /book-genesis or /book-genesis-codex to start writing."
-Write-Host ""
+& $pythonCommand.Source @launcherArgs @cliArgs
+exit $LASTEXITCODE

--- a/install.sh
+++ b/install.sh
@@ -1,77 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Book Genesis installer for macOS/Linux.
-# Installs full skill folders, including supporting references, to ~/.claude/.
+repo_dir="$(cd "$(dirname "$0")" && pwd)"
+target="${1:-claude}"
 
-REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
-SKILLS_DIR="$REPO_DIR/skills"
-KNOWLEDGE_DIR="$REPO_DIR/knowledge"
-AGENTS_DIR="$REPO_DIR/agents"
-TARGET_SKILLS="$HOME/.claude/skills"
-TARGET_KNOWLEDGE="$HOME/.claude/knowledge"
-TARGET_AGENTS="$HOME/.claude/agents"
+case "$target" in
+  claude|codex|kimi|shared) ;;
+  *)
+    echo "Usage: ./install.sh [claude|codex|kimi|shared] [--dry-run] [--force] [--include-legacy]" >&2
+    exit 2
+    ;;
+esac
 
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m'
+if [ "$#" -gt 0 ]; then
+  shift
+fi
 
-echo ""
-echo -e "${BLUE}Book Genesis${NC}"
-echo -e "${YELLOW}V4/V5 legacy system + portable Codex edition${NC}"
-echo ""
-echo -e "${YELLOW}Installing skills, supporting references, agents, and knowledge base${NC}"
-echo ""
-
-if [ ! -d "$SKILLS_DIR" ]; then
-  echo -e "${RED}Error: skills/ directory not found. Run this script from the repository root.${NC}"
+if command -v python3 >/dev/null 2>&1; then
+  python_bin="python3"
+elif command -v python >/dev/null 2>&1; then
+  python_bin="python"
+else
+  echo "Python 3 was not found in PATH." >&2
   exit 1
 fi
 
-mkdir -p "$TARGET_SKILLS" "$TARGET_KNOWLEDGE" "$TARGET_AGENTS"
-
-count=0
-for skill_dir in "$SKILLS_DIR"/*/; do
-  skill_name=$(basename "$skill_dir")
-  if [ -f "$skill_dir/SKILL.md" ]; then
-    rm -rf "$TARGET_SKILLS/$skill_name"
-    mkdir -p "$TARGET_SKILLS/$skill_name"
-    cp -R "$skill_dir". "$TARGET_SKILLS/$skill_name/"
-    echo -e "  ${GREEN}+${NC} $skill_name"
-    count=$((count + 1))
-  fi
-done
-
-kb_count=0
-if [ -d "$KNOWLEDGE_DIR" ]; then
-  for kb_file in "$KNOWLEDGE_DIR"/*.md; do
-    if [ -f "$kb_file" ]; then
-      cp "$kb_file" "$TARGET_KNOWLEDGE/"
-      echo -e "  ${GREEN}+${NC} knowledge/$(basename "$kb_file")"
-      kb_count=$((kb_count + 1))
-    fi
-  done
-fi
-
-agent_count=0
-if [ -d "$AGENTS_DIR" ]; then
-  for agent_file in "$AGENTS_DIR"/*.md; do
-    if [ -f "$agent_file" ]; then
-      cp "$agent_file" "$TARGET_AGENTS/"
-      echo -e "  ${GREEN}+${NC} agent/$(basename "$agent_file")"
-      agent_count=$((agent_count + 1))
-    fi
-  done
-fi
-
-echo ""
-echo -e "${GREEN}Done.${NC} $count skills + $agent_count agents + $kb_count knowledge files installed"
-echo ""
-echo -e "Skills:    ${BLUE}$TARGET_SKILLS${NC}"
-echo -e "Agents:    ${BLUE}$TARGET_AGENTS${NC}"
-echo -e "Knowledge: ${BLUE}$TARGET_KNOWLEDGE${NC}"
-echo ""
-echo "Open Claude Code and type /book-genesis or /book-genesis-codex to start writing."
-echo ""
+exec "$python_bin" "$repo_dir/runner/cli.py" install "$target" "$@"

--- a/runner/cli.py
+++ b/runner/cli.py
@@ -17,6 +17,11 @@ from runner.filesystem import (  # noqa: E402
     scaffold_project,
     validate_project,
 )
+from runner.distribution import (  # noqa: E402
+    install_suite,
+    supported_targets,
+    validate_suite,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -57,12 +62,57 @@ def build_parser() -> argparse.ArgumentParser:
     demo_parser.add_argument("--adapter", default="codex")
     demo_parser.add_argument("--model", default="gpt-5.5")
 
+    install_parser = subparsers.add_parser("install", help="Install portable skills for an agent runtime")
+    install_parser.add_argument("target", choices=supported_targets())
+    install_parser.add_argument("--dest", default=None, help="Override the runtime skills directory")
+    install_parser.add_argument("--include-legacy", action="store_true")
+    install_parser.add_argument("--force", action="store_true", help="Back up and replace conflicting skills")
+    install_parser.add_argument("--dry-run", action="store_true")
+
+    subparsers.add_parser("verify-suite", help="Validate portable skills, agent registry, and phase contracts")
+
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    if args.command == "verify-suite":
+        result = validate_suite()
+        for warning in result["warnings"]:
+            print(f"warning: {warning}")
+        if not result["ok"]:
+            print("Portable suite validation failed")
+            for error in result["errors"]:
+                print(error)
+            return 1
+        print("Portable suite validation ok")
+        return 0
+
+    if args.command == "install":
+        result = install_suite(
+            args.target,
+            destination=args.dest,
+            include_legacy=args.include_legacy,
+            force=args.force,
+            dry_run=args.dry_run,
+        )
+        for action in result["actions"]:
+            print(f"{action['action']}: {action['skill']}")
+        for action in result.get("legacy_actions", []):
+            print(f"{action['action']}: {action['component']}/{action['name']}")
+        if not result["ok"]:
+            print("Installation failed")
+            for error in result["errors"]:
+                print(error)
+            return 1
+        mode = "Dry run" if result.get("dry_run") else "Installed"
+        print(f"{mode} for {args.target}: {result['destination']}")
+        if result.get("backup"):
+            print(f"Backup: {result['backup']}")
+        return 0
+
     target = Path(args.path)
 
     if args.command == "init":

--- a/runner/distribution.py
+++ b/runner/distribution.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from hashlib import sha256
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+from typing import Mapping
+from uuid import uuid4
+
+from runner.filesystem import REPO_ROOT, load_manifest
+
+
+DISTRIBUTION_MANIFEST_PATH = REPO_ROOT / "distribution" / "portable-suite.json"
+INSTALL_RECORD = ".book-genesis-install.json"
+BACKUP_DIRECTORY = ".book-genesis-backups"
+
+
+def load_distribution_manifest() -> dict[str, object]:
+    data = json.loads(DISTRIBUTION_MANIFEST_PATH.read_text(encoding="utf-8"))
+    if data.get("schema_version") != 1:
+        raise ValueError("Unsupported portable suite manifest version")
+    return data
+
+
+def supported_targets() -> tuple[str, ...]:
+    targets = load_distribution_manifest().get("targets", {})
+    if not isinstance(targets, dict):
+        raise ValueError("Portable suite targets must be an object")
+    return tuple(sorted(str(name) for name in targets))
+
+
+def resolve_install_root(
+    target: str,
+    *,
+    destination: str | Path | None = None,
+    home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> Path:
+    manifest = load_distribution_manifest()
+    targets = manifest.get("targets", {})
+    if not isinstance(targets, dict) or target not in targets:
+        available = ", ".join(supported_targets())
+        raise KeyError(f"Unknown install target {target!r}. Available targets: {available}")
+
+    if destination is not None:
+        return Path(destination).expanduser().resolve()
+
+    spec = targets[target]
+    if not isinstance(spec, dict):
+        raise ValueError(f"Invalid install target definition for {target}")
+
+    environment = os.environ if environ is None else environ
+    home_env = str(spec.get("home_env", ""))
+    configured_home = environment.get(home_env, "") if home_env else ""
+    runtime_home = Path(configured_home).expanduser() if configured_home else (home or Path.home()) / str(
+        spec["default_home"]
+    )
+    return (runtime_home / str(spec["skills_dir"])).resolve()
+
+
+def selected_skills(*, include_legacy: bool = False) -> list[str]:
+    manifest = load_distribution_manifest()
+    skills = [str(name) for name in manifest.get("skills", [])]
+    if include_legacy:
+        skills.extend(str(name) for name in manifest.get("legacy_skills", []))
+    return skills
+
+
+def validate_suite() -> dict[str, object]:
+    manifest = load_distribution_manifest()
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    canonical_skill = str(manifest.get("canonical_skill", ""))
+    skills = selected_skills()
+    if not canonical_skill:
+        errors.append("canonical_skill is missing")
+    elif canonical_skill not in skills:
+        errors.append(f"canonical skill {canonical_skill!r} is not in portable skill list")
+
+    if len(skills) != len(set(skills)):
+        errors.append("portable skill list contains duplicates")
+
+    for skill_name in skills:
+        skill_file = REPO_ROOT / "skills" / skill_name / "SKILL.md"
+        if not skill_file.exists():
+            errors.append(f"missing skill entrypoint: {skill_file.relative_to(REPO_ROOT).as_posix()}")
+            continue
+        frontmatter = _read_frontmatter(skill_file)
+        if frontmatter.get("name") != skill_name:
+            errors.append(f"skill name mismatch in {skill_file.relative_to(REPO_ROOT).as_posix()}")
+        if not frontmatter.get("description"):
+            errors.append(f"skill description missing in {skill_file.relative_to(REPO_ROOT).as_posix()}")
+
+    registry_value = str(manifest.get("agent_registry", ""))
+    registry_path = REPO_ROOT / registry_value
+    if not registry_path.exists():
+        errors.append(f"agent registry missing: {registry_value}")
+    else:
+        registry_text = registry_path.read_text(encoding="utf-8")
+        for referenced in re.findall(r'^\s*skill:\s*"([^"]+)"', registry_text, flags=re.MULTILINE):
+            referenced_path = REPO_ROOT / referenced
+            if not referenced_path.exists():
+                errors.append(f"agent registry references missing file: {referenced}")
+            if referenced.startswith("skills/"):
+                dependency = referenced.split("/", 2)[1]
+                if dependency not in skills:
+                    errors.append(f"agent registry dependency is not packaged: {dependency}")
+
+    canonical_root = REPO_ROOT / "skills" / canonical_skill
+    phases = load_manifest()
+    labels = {phase.label for phase in phases}
+    gates = [phase.gate for phase in phases]
+    if len(gates) != len(set(gates)):
+        errors.append("canonical pipeline contains duplicate gates")
+    if "Phase 4: Adversarial Audit" not in labels:
+        errors.append("canonical pipeline is missing mandatory adversarial audit")
+    if "Phase 5: Literary Barrier Revision Loop" not in labels:
+        errors.append("canonical pipeline is missing literary barrier revision loop")
+    for phase in phases:
+        prompt_path = canonical_root / phase.prompt
+        if not prompt_path.exists():
+            errors.append(f"phase prompt missing: {phase.prompt}")
+        for reference in phase.references:
+            reference_path = canonical_root / reference
+            if not reference_path.exists():
+                errors.append(f"phase reference missing: {reference}")
+        if phase.next and phase.next not in labels:
+            errors.append(f"phase {phase.label!r} points to unknown next phase {phase.next!r}")
+
+    evaluator_protocol = canonical_root / "references" / "scoring" / "evaluator-protocol.md"
+    if not evaluator_protocol.exists():
+        errors.append("independent evaluator protocol is missing")
+
+    required_targets = {"claude", "codex", "kimi", "shared"}
+    target_names = set(supported_targets())
+    missing_targets = sorted(required_targets - target_names)
+    if missing_targets:
+        errors.append(f"portable targets missing: {', '.join(missing_targets)}")
+
+    legacy = [str(name) for name in manifest.get("legacy_skills", [])]
+    overlap = sorted(set(skills) & set(legacy))
+    if overlap:
+        warnings.append(f"legacy skills also included in portable profile: {', '.join(overlap)}")
+
+    legacy_claude = manifest.get("legacy_claude", {})
+    if not isinstance(legacy_claude, dict):
+        errors.append("legacy_claude must be an object")
+    else:
+        for key in ("agents_dir", "knowledge_dir"):
+            source_dir = REPO_ROOT / str(legacy_claude.get(key, ""))
+            if not source_dir.is_dir():
+                errors.append(f"legacy Claude source directory missing: {source_dir.name}")
+
+    return {"ok": not errors, "errors": errors, "warnings": warnings}
+
+
+def install_suite(
+    target: str,
+    *,
+    destination: str | Path | None = None,
+    include_legacy: bool = False,
+    force: bool = False,
+    dry_run: bool = False,
+    home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    validation = validate_suite()
+    if not validation["ok"]:
+        return {
+            "ok": False,
+            "destination": "",
+            "actions": [],
+            "legacy_actions": [],
+            "conflicts": [],
+            "errors": list(validation["errors"]),
+        }
+
+    destination_root = resolve_install_root(
+        target,
+        destination=destination,
+        home=home,
+        environ=environ,
+    )
+    source_root = (REPO_ROOT / "skills").resolve()
+    if destination_root == source_root:
+        return {
+            "ok": False,
+            "destination": str(destination_root),
+            "actions": [],
+            "legacy_actions": [],
+            "conflicts": [],
+            "errors": ["installation destination cannot be repository source skills directory"],
+        }
+    if destination_root.exists() and not destination_root.is_dir():
+        return {
+            "ok": False,
+            "destination": str(destination_root),
+            "actions": [],
+            "legacy_actions": [],
+            "conflicts": [],
+            "errors": ["installation destination exists and is not a directory"],
+        }
+
+    actions: list[dict[str, str]] = []
+    conflicts: list[str] = []
+    skills = selected_skills(include_legacy=include_legacy)
+    missing_sources = [skill_name for skill_name in skills if not (source_root / skill_name / "SKILL.md").exists()]
+    if missing_sources:
+        return {
+            "ok": False,
+            "destination": str(destination_root),
+            "actions": [],
+            "legacy_actions": [],
+            "conflicts": [],
+            "errors": [f"source skills missing: {', '.join(missing_sources)}"],
+        }
+
+    for skill_name in skills:
+        source = source_root / skill_name
+        destination_skill = destination_root / skill_name
+        if not destination_skill.exists():
+            action = "install"
+        elif destination_skill.is_dir() and _tree_digest(source) == _tree_digest(destination_skill):
+            action = "unchanged"
+        elif force:
+            action = "replace"
+        else:
+            action = "conflict"
+            conflicts.append(skill_name)
+        actions.append({"skill": skill_name, "action": action, "destination": str(destination_skill)})
+
+    legacy_actions = _plan_legacy_claude_files(
+        target=target,
+        include_legacy=include_legacy,
+        destination_root=destination_root,
+        force=force,
+    )
+    for item in legacy_actions:
+        if item["action"] == "conflict":
+            conflicts.append(f"{item['component']}/{item['name']}")
+
+    if conflicts:
+        return {
+            "ok": False,
+            "destination": str(destination_root),
+            "actions": actions,
+            "legacy_actions": legacy_actions,
+            "conflicts": conflicts,
+            "errors": ["existing skill directories differ; rerun with --force to back them up and replace them"],
+        }
+
+    if dry_run:
+        return {
+            "ok": True,
+            "destination": str(destination_root),
+            "actions": actions,
+            "legacy_actions": legacy_actions,
+            "conflicts": [],
+            "errors": [],
+            "dry_run": True,
+        }
+
+    destination_root.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    backup_root: Path | None = None
+
+    for item in actions:
+        if item["action"] == "unchanged":
+            continue
+        skill_name = item["skill"]
+        source = source_root / skill_name
+        destination_skill = destination_root / skill_name
+        stage_root = destination_root / f".book-genesis-stage-{uuid4().hex}"
+        stage_skill = stage_root / skill_name
+        previous_backup: Path | None = None
+        try:
+            shutil.copytree(source, stage_skill)
+            if destination_skill.exists():
+                backup_root = destination_root / BACKUP_DIRECTORY / timestamp
+                backup_root.mkdir(parents=True, exist_ok=True)
+                previous_backup = backup_root / skill_name
+                destination_skill.rename(previous_backup)
+            stage_skill.rename(destination_skill)
+        except Exception:
+            if previous_backup is not None and previous_backup.exists() and not destination_skill.exists():
+                previous_backup.rename(destination_skill)
+            raise
+        finally:
+            shutil.rmtree(stage_root, ignore_errors=True)
+
+    for item in legacy_actions:
+        if item["action"] == "unchanged":
+            continue
+        source = Path(item["source"])
+        destination_file = Path(item["destination"])
+        stage_root = destination_root / f".book-genesis-stage-{uuid4().hex}"
+        stage_file = stage_root / item["component"] / item["name"]
+        previous_backup: Path | None = None
+        try:
+            stage_file.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, stage_file)
+            destination_file.parent.mkdir(parents=True, exist_ok=True)
+            if destination_file.exists():
+                backup_root = destination_root / BACKUP_DIRECTORY / timestamp
+                previous_backup = backup_root / item["component"] / item["name"]
+                previous_backup.parent.mkdir(parents=True, exist_ok=True)
+                destination_file.rename(previous_backup)
+            stage_file.rename(destination_file)
+        except Exception:
+            if previous_backup is not None and previous_backup.exists() and not destination_file.exists():
+                previous_backup.rename(destination_file)
+            raise
+        finally:
+            shutil.rmtree(stage_root, ignore_errors=True)
+
+    installed = {
+        item["skill"]: _tree_digest(destination_root / item["skill"])
+        for item in actions
+    }
+    record = {
+        "schema_version": 1,
+        "suite": load_distribution_manifest()["suite_name"],
+        "target": target,
+        "canonical_skill": load_distribution_manifest()["canonical_skill"],
+        "include_legacy": include_legacy,
+        "installed_at_utc": datetime.now(timezone.utc).isoformat(),
+        "skills": installed,
+        "legacy_claude_files": {
+            f"{item['component']}/{item['name']}": _file_digest(Path(item["destination"]))
+            for item in legacy_actions
+        },
+    }
+    (destination_root / INSTALL_RECORD).write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+
+    return {
+        "ok": True,
+        "destination": str(destination_root),
+        "actions": actions,
+        "legacy_actions": legacy_actions,
+        "conflicts": [],
+        "errors": [],
+        "dry_run": False,
+        "backup": str(backup_root) if backup_root else "",
+    }
+
+
+def _read_frontmatter(path: Path) -> dict[str, str]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    values: dict[str, str] = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return values
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        values[key.strip()] = value.strip().strip('"')
+    return {}
+
+
+def _plan_legacy_claude_files(
+    *,
+    target: str,
+    include_legacy: bool,
+    destination_root: Path,
+    force: bool,
+) -> list[dict[str, str]]:
+    if target != "claude" or not include_legacy:
+        return []
+
+    manifest = load_distribution_manifest()
+    legacy = manifest.get("legacy_claude", {})
+    if not isinstance(legacy, dict):
+        return []
+
+    runtime_root = destination_root.parent
+    collections = (
+        ("agents", REPO_ROOT / str(legacy["agents_dir"]), runtime_root / "agents"),
+        ("knowledge", REPO_ROOT / str(legacy["knowledge_dir"]), runtime_root / "knowledge"),
+    )
+    actions: list[dict[str, str]] = []
+    for component, source_dir, destination_dir in collections:
+        for source in sorted(source_dir.glob("*.md")):
+            destination_file = destination_dir / source.name
+            if not destination_file.exists():
+                action = "install"
+            elif destination_file.is_file() and _file_digest(source) == _file_digest(destination_file):
+                action = "unchanged"
+            elif force:
+                action = "replace"
+            else:
+                action = "conflict"
+            actions.append(
+                {
+                    "component": component,
+                    "name": source.name,
+                    "action": action,
+                    "source": str(source),
+                    "destination": str(destination_file),
+                }
+            )
+    return actions
+
+
+def _file_digest(path: Path) -> str:
+    return sha256(path.read_bytes()).hexdigest() if path.is_file() else ""
+
+
+def _tree_digest(root: Path) -> str:
+    digest = sha256()
+    if not root.is_dir():
+        return ""
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        relative = path.relative_to(root).as_posix().encode("utf-8")
+        digest.update(len(relative).to_bytes(4, "big"))
+        digest.update(relative)
+        content = path.read_bytes()
+        digest.update(len(content).to_bytes(8, "big"))
+        digest.update(content)
+    return digest.hexdigest()

--- a/runner/filesystem.py
+++ b/runner/filesystem.py
@@ -8,7 +8,7 @@ from typing import Dict, List
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-SKILL_ROOT = REPO_ROOT / "skills" / "book-genesis-codex"
+SKILL_ROOT = REPO_ROOT / "skills" / "book-genesis"
 MANIFEST_PATH = SKILL_ROOT / "references" / "pipeline" / "manifest.yaml"
 
 
@@ -17,6 +17,7 @@ class Phase:
     key: str
     label: str
     prompt: str
+    references: List[str]
     gate: str
     outputs: List[str]
     next: str
@@ -33,6 +34,7 @@ class AgentSpec:
     outputs: List[str]
     gates: List[str]
     score_floor: str
+    blind: bool
 
 
 ARTIFACT_HEADINGS: Dict[str, str] = {
@@ -60,6 +62,7 @@ def load_manifest() -> List[Phase]:
             key=key,
             label=str(entry.get("label", "")),
             prompt=str(entry.get("prompt", "")),
+            references=list(entry.get("references", [])),
             gate=str(entry.get("gate", "")),
             outputs=list(entry.get("outputs", [])),
             next=str(entry.get("next", "")),
@@ -81,6 +84,7 @@ def load_agent_registry() -> List[AgentSpec]:
             outputs=list(entry.get("outputs", [])),
             gates=list(entry.get("gates", [])),
             score_floor=str(entry.get("score_floor", "")),
+            blind=str(entry.get("blind", "false")).lower() == "true",
         )
         for key, entry in entries.items()
     ]
@@ -170,6 +174,13 @@ def prepare_phase(target: Path) -> Path:
     prompt_path = SKILL_ROOT / phase.prompt
     prompt_text = prompt_path.read_text(encoding="utf-8")
     output_list = "\n".join(f"- {item}" for item in phase.outputs)
+    reference_sections = []
+    for reference in phase.references:
+        reference_path = SKILL_ROOT / reference
+        reference_text = reference_path.read_text(encoding="utf-8").rstrip()
+        reference_sections.append(f"## Required Reference: {reference}\n\n{reference_text}\n")
+    references_text = "\n".join(reference_sections)
+    reference_appendix = f"\n{references_text}" if references_text else ""
 
     packet = (
         f"# Current Phase\n\n"
@@ -179,6 +190,7 @@ def prepare_phase(target: Path) -> Path:
         f"- Required outputs:\n{output_list}\n\n"
         f"## Phase Prompt\n\n"
         f"{prompt_text.rstrip()}\n"
+        f"{reference_appendix}"
     )
 
     work_dir = target / "work"
@@ -281,6 +293,19 @@ def prepare_agent_packet(target: Path, agent_key: str) -> Path:
     input_lines = _path_status_lines(target, agent.inputs)
     output_lines = "\n".join(f"- `{item}`" for item in agent.outputs) or "- No required outputs listed."
     gate_lines = "\n".join(f"- {item}" for item in agent.gates) or "- No gates listed."
+    score_floor = "withheld from blind evaluator" if agent.blind else (agent.score_floor or "project default")
+    blind_rule = (
+        "- Blind evaluation: yes\n"
+        "- Do not request or infer the target score, previous scores, writer self-report, or revision rationale.\n"
+        if agent.blind
+        else "- Blind evaluation: no\n"
+    )
+    operating_rule = (
+        "Produce a raw evidence-backed evaluation only. Do not approve readiness, apply a pass threshold, or edit the manuscript."
+        if agent.blind
+        else "Produce durable files only. Do not claim market-ready, viral-ready, or 8.5+ readiness unless every listed gate passes with evidence. "
+        "When a gate fails, write blockers and revision tickets instead of inflating scores."
+    )
 
     skill_path = REPO_ROOT / agent.skill
     skill_excerpt = ""
@@ -293,8 +318,9 @@ def prepare_agent_packet(target: Path, agent_key: str) -> Path:
         f"# Agent Packet: {agent.label}\n\n"
         f"- Agent key: `{agent.key}`\n"
         f"- Timing: {agent.timing}\n"
-        f"- Score floor: {agent.score_floor or 'project default'}\n"
+        f"- Score floor: {score_floor}\n"
         f"- Skill: `{agent.skill}`\n\n"
+        f"{blind_rule}\n"
         "## Mission\n\n"
         f"{agent.mission}\n\n"
         "## Input Status\n\n"
@@ -304,8 +330,7 @@ def prepare_agent_packet(target: Path, agent_key: str) -> Path:
         "## Gates\n\n"
         f"{gate_lines}\n\n"
         "## Operating Rule\n\n"
-        "Produce durable files only. Do not claim market-ready, viral-ready, or 8.5+ readiness unless every listed gate passes with evidence. "
-        "When a gate fails, write blockers and revision tickets instead of inflating scores.\n\n"
+        f"{operating_rule}\n\n"
         "## Skill Prompt\n\n"
         f"{skill_excerpt}\n"
     )
@@ -493,7 +518,10 @@ def _project_state_template(
         f"  language: \"{_escape_yaml(language)}\"\n"
         "  genre: \"\"\n"
         "  audience: \"\"\n"
-        "  target_length: \"\"\n\n"
+        "  positioning: \"\"\n"
+        "  target_range_words: \"\"\n"
+        "  target_floor_words: 0\n"
+        "  target_ceiling_words: 0\n\n"
         "runtime:\n"
         f"  adapter: \"{_escape_yaml(adapter)}\"\n"
         f"  model_family: \"{_infer_family(model_name)}\"\n"
@@ -507,7 +535,11 @@ def _project_state_template(
         "  generated: []\n\n"
         "manuscript:\n"
         "  chapter_count: 0\n"
+        "  chapter_count_planned: 0\n"
+        "  average_words_per_chapter_planned: 0\n"
+        "  word_count_actual: 0\n"
         "  completed_chapters: []\n"
+        "  length_gate: \"pending\"\n"
         "  status: \"not_started\"\n\n"
         "gates:\n"
         f"{gates}\n"

--- a/scripts/distribution/hackernews-post.mjs
+++ b/scripts/distribution/hackernews-post.mjs
@@ -11,7 +11,7 @@ The current version is smaller and agent-agnostic: durable project files, one ac
 It runs in Claude Code, Codex, Antigravity, Kimi, or any agent that can read and write files. No proprietary format, no lock-in.
 
 Repo:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Useful files:
 - docs/book-gallery.md (10-book proof gallery)
@@ -76,7 +76,7 @@ await titleInput.fill(postTitle);
 
 // Fill URL
 const urlInput = page.locator('input[name="url"]');
-await urlInput.fill("https://github.com/felipelobomotta-blip/best-seller-studio");
+await urlInput.fill("https://github.com/felipelobomotta-blip/book-genesis-v4");
 
 // HN text area (may not be visible if URL is filled)
 const textInput = page.locator('textarea[name="text"]');

--- a/scripts/distribution/linkedin-post.mjs
+++ b/scripts/distribution/linkedin-post.mjs
@@ -35,7 +35,7 @@ If you're building with AI agents — whether books, code, or operations — the
 Repo and proof layer in the comments.`;
 
 const commentBody = `Link to the repository with the pipeline, cover gallery, case studies, and portable skill:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Key docs:
 - docs/book-gallery.md (10+ project proof)

--- a/scripts/distribution/reddit-launch.mjs
+++ b/scripts/distribution/reddit-launch.mjs
@@ -1,6 +1,6 @@
 import { chromium } from "playwright";
 
-const repoUrl = "https://github.com/felipelobomotta-blip/best-seller-studio";
+const repoUrl = "https://github.com/felipelobomotta-blip/book-genesis-v4";
 const subreddit = "ClaudeAI";
 const postTitle = `I stress-tested AI agents on 10+ book projects in under 30 days. The 19-skill version was worse.`;
 

--- a/scripts/distribution/twitter-thread.mjs
+++ b/scripts/distribution/twitter-thread.mjs
@@ -7,7 +7,7 @@ const tweets = [
   `So I rebuilt it as a smaller, file-backed core:\n\n• One active phase at a time\n• PROJECT_STATE.yaml + ASSUMPTIONS.md\n• Draft first, judge after\n• Adversarial audit before final score\n• Editorial package only after the manuscript survives critique`,
   `The result:\n\n10+ book projects with covers, case studies, scoring artifacts, and outlines.\n\nThe manuscripts are private.\n\nThe pipeline, proof layer, and portable skill are open-source.`,
   `It runs as a file-backed workflow in:\n\n• Claude Code\n• Codex\n• Antigravity\n• Kimi\n• Any agent that can read/write project files\n\nNo lock-in. No proprietary format. Just durable state files and phase prompts.`,
-  `If you're building long-form agent workflows, I'm curious:\n\nHave you seen the same tradeoff — more live constraints improving consistency but hurting voice?\n\nRepo + proof gallery:\nhttps://github.com/felipelobomotta-blip/best-seller-studio`,
+  `If you're building long-form agent workflows, I'm curious:\n\nHave you seen the same tradeoff — more live constraints improving consistency but hurting voice?\n\nRepo + proof gallery:\nhttps://github.com/felipelobomotta-blip/book-genesis-v4`,
   `The lesson that took me 10 books to learn:\n\nA pipeline beats a prompt.\n\nBut a smaller pipeline beats a bigger one.`
 ];
 

--- a/skills/book-bestseller-studio/SKILL.md
+++ b/skills/book-bestseller-studio/SKILL.md
@@ -5,7 +5,7 @@ description: Use when the user wants a complete book-production system aimed at 
 
 # Book Bestseller Studio
 
-This is the umbrella skill for creating a complete book at market level. It does not replace `book-genesis` or the portable `book-genesis-codex` core; it coordinates the specialist skills and adds commercial gates.
+This is the umbrella skill for creating a complete book at market level. It does not replace canonical `book-genesis`; it coordinates specialist skills and adds commercial gates.
 
 Use this when the user says things like:
 
@@ -29,6 +29,8 @@ Use this when the user says things like:
 - `editorial-package`: logline, back-cover copy, synopsis, query letter, cover brief.
 - `launch-strategy`: go-to-market, offer, launch calendar, proof-driven positioning.
 - `content-strategy`: audience-building and content plan around the book.
+
+`launch-strategy` and `content-strategy` are optional external companions. Do not block manuscript completion when they are not installed.
 
 ## Operating Rule
 
@@ -61,6 +63,17 @@ Default project layout:
 8. Run `literary-agent-panel` and/or `book-swarm-panel` again after revision.
 9. Run `editorial-package` only after manuscript passes product gates.
 10. Run `launch-strategy` and `content-strategy` for public-launch readiness.
+
+## Portable Agent Dispatch
+
+Read `references/dispatch.md` and use `references/agent-registry.yaml` for specialist ownership. Prepare packets with `python runner/cli.py prepare-agent-packet <project> <agent>` when the runner is available.
+
+- Claude Code: dispatch a custom or general-purpose subagent with the packet.
+- Codex: dispatch an isolated subagent with the packet when available.
+- Kimi Code: dispatch a fresh built-in subagent with the packet.
+- No subagents: run roles sequentially, mark evaluation independence as degraded, and never call self-scoring independent.
+
+Editorial rules remain identical across adapters. Platform-specific agent files may select tools or models, but must not redefine gates or scoring.
 
 ## Commercial Gates
 

--- a/skills/book-bestseller-studio/references/agent-registry.yaml
+++ b/skills/book-bestseller-studio/references/agent-registry.yaml
@@ -166,7 +166,7 @@ swarm_director:
 
 adversarial_auditor:
   label: "Adversarial Auditor"
-  skill: "skills/book-genesis-codex/SKILL.md"
+  skill: "skills/book-genesis/SKILL.md"
   mission: "Attack premise, structure, opening, pacing, coherence, market promise, AI texture, and score inflation before final score."
   timing: "Mandatory Phase 4."
   score_floor: "Blocks final score until audit complete"
@@ -180,6 +180,26 @@ adversarial_auditor:
     - "Final score cannot run before this output exists."
     - "Weakest dimension named."
     - "Score inflation risks documented."
+
+blind_literary_critic:
+  label: "Blind Literary Critic"
+  skill: "skills/book-genesis/references/scoring/evaluator-protocol.md"
+  mission: "Read the declared manuscript coverage in a fresh context, score every literary lens with cited evidence, and produce a raw report without seeing pass thresholds, prior scores, writer self-reports, or revision rationale."
+  timing: "Phase 5 before revision and after every revision iteration. Dispatch at least three independent instances."
+  score_floor: "withheld"
+  blind: "true"
+  inputs:
+    - "manuscript/chapters"
+    - "artifacts/03-characters.md"
+    - "artifacts/04-theme.md"
+    - "artifacts/05-outline.md"
+  outputs:
+    - "evaluations/blind"
+  gates:
+    - "Coverage is declared as full manuscript or named sample."
+    - "Every score above 8.0 cites textual or structural evidence."
+    - "Strongest and weakest passages are located."
+    - "No target threshold or prior score appears in evaluator inputs."
 
 revision_editor:
   label: "Revision Editor"
@@ -203,12 +223,13 @@ revision_editor:
 
 scorekeeper:
   label: "Scorekeeper"
-  skill: "skills/book-genesis-codex/references/scoring/genesis-score-codex.md"
-  mission: "Score only after audit/revision, enforce 8.5+ target as calibrated threshold, and block publication claims when floor dimensions fail."
-  timing: "Phase 5 Final Score."
+  skill: "skills/book-genesis/references/scoring/genesis-score-codex.md"
+  mission: "Aggregate frozen blind-evaluator reports after audit/revision, apply calibration and the 8.5+ target, and block publication claims when floor dimensions or evaluation integrity fail."
+  timing: "Phase 6 Final Score."
   score_floor: "8.5 calibrated floor target"
   inputs:
     - "artifacts/08-adversarial-audit.md"
+    - "evaluations/blind"
     - "evaluations/book-swarm"
     - "manuscript/chapters"
   outputs:
@@ -222,7 +243,7 @@ package_strategist:
   label: "Package Strategist"
   skill: "skills/editorial-package/SKILL.md"
   mission: "Build logline, cover copy, synopsis, query/pitch, cover brief, metadata angle, and viral hooks that match the manuscript instead of overpromising."
-  timing: "Phase 6 and package-reaction loops."
+  timing: "Phase 7 and package-reaction loops."
   score_floor: "8.5 package/market target"
   inputs:
     - "artifacts/09-genesis-score-codex.md"

--- a/skills/book-bestseller-studio/references/dispatch.md
+++ b/skills/book-bestseller-studio/references/dispatch.md
@@ -10,6 +10,7 @@ The craft target is a calibrated `8.5+` manuscript/package system. This is not a
 - no average-score hiding of weak floor dimensions
 - no market-ready claim without product, manuscript, package, and launch gates
 - no viral claim without hypothesis, framing risk, and test plan
+- no independent-quality claim without evaluator isolation grade
 
 ## Team Order
 
@@ -23,11 +24,13 @@ The craft target is a calibrated `8.5+` manuscript/package system. This is not a
 8. `continuity_editor`
 9. `swarm_director`
 10. `adversarial_auditor`
-11. `revision_editor`
-12. `scorekeeper`
-13. `package_strategist`
-14. `viral_framing_strategist`
-15. `launch_strategist`
+11. `blind_literary_critic` (at least three fresh instances)
+12. `revision_editor`
+13. `blind_literary_critic` again after revision
+14. `scorekeeper`
+15. `package_strategist`
+16. `viral_framing_strategist`
+17. `launch_strategist`
 
 Loop back from any gate failure to the smallest responsible specialist. Do not rewrite the whole book when a ticket has a local owner.
 
@@ -37,6 +40,7 @@ Loop back from any gate failure to the smallest responsible specialist. Do not r
 python runner/cli.py prepare-agent-packet my-book market_researcher
 python runner/cli.py prepare-agent-packet my-book prose_writer
 python runner/cli.py prepare-agent-packet my-book swarm_director
+python runner/cli.py prepare-agent-packet my-book blind_literary_critic
 ```
 
 Packets are written to:
@@ -48,3 +52,5 @@ my-book/work/agent-packets/<agent>.md
 ## Scoring Discipline
 
 `8.5+` means calibrated evidence after revision. Internal enthusiasm is discounted. Public reaction is scenario-based. Cultural or lived-experience approval requires human validation.
+
+Use `skills/book-genesis/references/scoring/evaluator-protocol.md`. Writer, revision editor, and approving evaluator must use separate contexts when runtime supports them. Record Grade A, B, or C in final score.

--- a/skills/book-genesis/SKILL.md
+++ b/skills/book-genesis/SKILL.md
@@ -3,9 +3,9 @@ name: book-genesis
 description: Use when the user wants to create, plan, draft, evaluate, revise, package, or run a complete AI-assisted book pipeline. Book Genesis turns a one-line idea into a book project with intake, foundation, architecture, drafting, adversarial audit, Genesis Score, and editorial package artifacts.
 ---
 
-# Book Genesis
+# Book Genesis Universal Core
 
-Book Genesis is Felipe's local book-production pipeline adapted for Codex. It uses the newer `book-genesis-codex` core as the canonical workflow.
+Book Genesis is Felipe's portable book-production pipeline for Claude Code, Codex, Kimi Code, and other file-aware agents. This folder is the canonical workflow. Platform adapters install the same files without changing editorial rules.
 
 Use this skill for:
 
@@ -70,6 +70,8 @@ Read only the prompt for the active phase:
 - Final Score: `references/scoring/genesis-score-codex.md`
 - Editorial Package: `references/prompts/editorial-package.md`
 
+Before any independent or final score, read `references/scoring/evaluator-protocol.md` and record the achieved independence grade.
+
 `references/prompts/orchestrator.md` contains the portable orchestration rules.
 
 ## Operating Loop
@@ -99,6 +101,7 @@ Read only the prompt for the active phase:
 
 - Prefer fewer constraints during drafting; evaluate and repair afterward.
 - Separate drafting, audit, scoring, and editorial judgment in the workflow.
+- Keep writer, revision editor, and final evaluator in isolated contexts when the runtime supports subagents.
 - Use the Genesis Score floor principle: the book is only as strong as its weakest major dimension.
 - Treat internal literary scores as inflated until calibrated. Apply the score calibration rules in the scoring reference before claiming a threshold was reached.
 - Do not optimize prose to satisfy rubrics while drafting. The writer writes; the critic and editor operate after text exists.
@@ -114,5 +117,5 @@ Use these only when relevant and already available:
 - `copy-editing` for prose-level cleanup
 - `book-swarm-panel` for MiroFish-style simulated reader swarms, niche-risk scouting, public-opinion tests, heatmaps, interviews, and revision tickets
 - `humanizer` for less synthetic phrasing
-- `launch-strategy` or `content-strategy` for go-to-market assets
+- `launch-strategy` or `content-strategy` for go-to-market assets when separately installed
 - `imagegen` or cover-specific workflows for cover ideation

--- a/skills/book-genesis/references/pipeline/manifest.yaml
+++ b/skills/book-genesis/references/pipeline/manifest.yaml
@@ -47,6 +47,8 @@ phase_4_adversarial_audit:
 phase_5_literary_barrier_loop:
   label: "Phase 5: Literary Barrier Revision Loop"
   prompt: "references/prompts/literary-barrier-loop.md"
+  references:
+    - "references/scoring/evaluator-protocol.md"
   gate: "literary_barrier_loop"
   outputs:
     - "evaluations/literary-barrier-loop.md"
@@ -56,6 +58,8 @@ phase_5_literary_barrier_loop:
 phase_6_final_score:
   label: "Phase 6: Final Score"
   prompt: "references/scoring/genesis-score-codex.md"
+  references:
+    - "references/scoring/evaluator-protocol.md"
   gate: "final_score"
   outputs:
     - "artifacts/09-genesis-score-codex.md"

--- a/skills/book-genesis/references/prompts/adversarial-audit.md
+++ b/skills/book-genesis/references/prompts/adversarial-audit.md
@@ -1,6 +1,6 @@
 # Adversarial Audit Prompt
 
-You are responsible for Phase 4 of `book-genesis-codex`.
+You are responsible for Phase 4 of `book-genesis`.
 
 ## Core Principle
 

--- a/skills/book-genesis/references/prompts/architecture.md
+++ b/skills/book-genesis/references/prompts/architecture.md
@@ -1,6 +1,6 @@
 # Architecture Prompt
 
-You are responsible for Phase 2 of `book-genesis-codex`.
+You are responsible for Phase 2 of `book-genesis`.
 
 ## Goal
 

--- a/skills/book-genesis/references/prompts/drafting.md
+++ b/skills/book-genesis/references/prompts/drafting.md
@@ -1,6 +1,6 @@
 # Drafting Prompt
 
-You are responsible for Phase 3 of `book-genesis-codex`.
+You are responsible for Phase 3 of `book-genesis`.
 
 ## Goal
 

--- a/skills/book-genesis/references/prompts/editorial-package.md
+++ b/skills/book-genesis/references/prompts/editorial-package.md
@@ -1,6 +1,6 @@
 # Editorial Package Prompt
 
-You are responsible for Phase 6 of `book-genesis-codex`.
+You are responsible for Phase 7 of `book-genesis`.
 
 ## Goal
 

--- a/skills/book-genesis/references/prompts/foundation.md
+++ b/skills/book-genesis/references/prompts/foundation.md
@@ -1,6 +1,6 @@
 # Foundation Prompt
 
-You are responsible for Phase 1 of `book-genesis-codex`.
+You are responsible for Phase 1 of `book-genesis`.
 
 ## Goal
 

--- a/skills/book-genesis/references/prompts/intake.md
+++ b/skills/book-genesis/references/prompts/intake.md
@@ -1,6 +1,6 @@
 # Intake Prompt
 
-You are responsible for Phase 0 of `book-genesis-codex`.
+You are responsible for Phase 0 of `book-genesis`.
 
 ## Input Contract
 
@@ -36,6 +36,9 @@ Create and update:
 - genre
 - audience
 - target length
+- positioning: full-length, novella, short novel, serial installment, or nonfiction format
+- target range, floor, and ceiling in words
+- planned chapter count and average words per chapter
 - narrative mode
 - reader promise
 

--- a/skills/book-genesis/references/prompts/literary-barrier-loop.md
+++ b/skills/book-genesis/references/prompts/literary-barrier-loop.md
@@ -1,6 +1,6 @@
 # Literary Barrier Revision Loop
 
-You are responsible for Phase 5 of `book-genesis-codex`.
+You are responsible for coordinating Phase 5 of `book-genesis`.
 
 ## Goal
 
@@ -13,18 +13,32 @@ This phase exists because a manuscript can pass ordinary structure checks and st
 Read:
 
 - `artifacts/08-adversarial-audit.md`
+- `references/scoring/evaluator-protocol.md`
 - all manuscript chapters
 - foundation and architecture artifacts
 - the latest Genesis Score report if one already exists
 - prior files in `evaluations/` if this is not the first loop
 
+## Role Separation
+
+Do not let one context both revise and approve its own revision when isolated subagents are available.
+
+1. At least three `blind_literary_critic` instances score and create evidence-backed reports.
+2. A revision editor receives the tickets and manuscript, but not the desired numeric result.
+3. A fresh blind evaluator rescores the revised manuscript.
+4. The orchestrator applies calibration and the threshold after evaluator reports exist.
+
+When the runtime cannot isolate contexts, mark Evaluation Independence Grade `C`. Grade C can guide revision but cannot support a strong independent-quality claim.
+
 ## Calibration Rule
 
 Internal evaluation is biased upward. Before deciding that the book cleared the barrier:
 
-1. score each critical lens from 1 to 10
-2. subtract 0.8 from each lens score unless there is external human critique attached in `evaluations/`
-3. use the lowest calibrated lens as the Literary Barrier Score
+1. collect separate evaluator reports before revealing the target threshold
+2. use the median score for each lens
+3. subtract 0.8 from each lens median unless external human critique is attached in `evaluations/`
+4. use the lowest calibrated lens as the Literary Barrier Score
+5. send disagreements of 1.5 points or more to another evaluator instead of averaging them away
 
 Do not claim the threshold was reached unless the calibrated floor is above the target.
 
@@ -44,18 +58,19 @@ Score and diagnose these lenses separately:
 
 Repeat until the calibrated Literary Barrier Score is above target or a blocker is explicit:
 
-1. Identify the lowest scoring lens.
-2. Name the exact passages or structural zones causing the ceiling.
-3. Choose the smallest revision class that can raise the ceiling:
+1. Prepare `blind_literary_critic` packet and dispatch at least three fresh instances under `evaluator-protocol.md`.
+2. Identify the lowest scoring lens from evidence-backed reports.
+3. Name the exact passages or structural zones causing the ceiling.
+4. Write `evaluations/revision-plan.md` using the smallest revision class that can raise the ceiling:
    - structural revision
    - connective revision
    - character deepening
    - voice recalibration
    - line edit
    - cut or merge
-4. Revise the manuscript files directly.
-5. Save a revision note in `evaluations/literary-barrier-loop.md`.
-6. Rescore all lenses, including any lens that might have been damaged.
+5. Dispatch a revision editor to revise the manuscript files directly.
+6. Save a revision note in `evaluations/literary-barrier-loop.md`.
+7. Dispatch a fresh blind evaluator to rescore all lenses, including any lens that might have been damaged.
 
 ## Revision Rules
 
@@ -82,6 +97,7 @@ Stop with blocker only when:
 - the manuscript lacks enough draft material to evaluate
 - the next improvement requires author decision, lived material, external research, or human critique
 - further revision would be speculative churn
+- five revision iterations failed to clear the calibrated floor, unless user explicitly raises the limit
 
 ## Output
 
@@ -95,3 +111,11 @@ Save or update `evaluations/literary-barrier-loop.md` with:
 - passages changed
 - strengths preserved
 - current verdict: `CONTINUE`, `APPROVED`, or `BLOCKED`
+
+Save or update `evaluations/revision-plan.md` with:
+
+- ticket identifiers and severity
+- cited passages or structural zones
+- assigned revision class
+- strengths that must be preserved
+- acceptance evidence required from the next evaluator

--- a/skills/book-genesis/references/prompts/orchestrator.md
+++ b/skills/book-genesis/references/prompts/orchestrator.md
@@ -1,6 +1,6 @@
-# book-genesis-codex Orchestrator Prompt
+# Book Genesis Orchestrator Prompt
 
-You are the portable orchestrator for `book-genesis-codex`.
+You are the portable orchestrator for `book-genesis`.
 
 Your job is to turn one user idea into a complete book project using the shared core contracts and the shared pipeline.
 
@@ -14,6 +14,7 @@ Mandatory rules:
 - use `literary-barrier-loop.md` for Phase 5 when a quality threshold is active
 - use `editorial-package.md` for Phase 7
 - never skip Phase 4: Adversarial Audit
+- use a fresh evaluator context and `references/scoring/evaluator-protocol.md` for critical scores
 - only use the canonical phase order
 
 Pipeline:

--- a/skills/book-genesis/references/scoring/evaluator-protocol.md
+++ b/skills/book-genesis/references/scoring/evaluator-protocol.md
@@ -1,0 +1,70 @@
+# Independent Evaluator Protocol
+
+Use this protocol for Literary Barrier and final Genesis Score evaluations. Goal: reduce self-grading, threshold anchoring, and evidence-free praise.
+
+## Blind Inputs
+
+Give evaluators only:
+
+- manuscript files or declared sample
+- stable foundation and architecture facts needed for continuity
+- scoring rubric
+- market position when Market is being scored
+
+Do not give evaluators:
+
+- writer self-reports
+- revision rationale
+- desired pass threshold
+- previous numeric scores
+- another evaluator's verdict
+
+## Role Boundaries
+
+- Writer drafts. Writer never issues final score.
+- Evaluator diagnoses and scores. Evaluator never edits manuscript.
+- Revision editor receives evidence-backed tickets, then edits.
+- Fresh evaluator verifies revisions without reading previous numeric scores.
+- Orchestrator aggregates reports and applies pass thresholds after scoring.
+
+## Independence Grades
+
+- `A`: three or more fresh evaluator contexts; at least two model families when available.
+- `B`: three or more fresh evaluator contexts using same model family.
+- `C`: evaluation occurs in writer or revision context, or prior scores leak into evaluation.
+
+Grade C is diagnostic only. Do not describe Grade C results as independent critical validation.
+
+## Required Evaluator Output
+
+Each evaluator must provide:
+
+- score per dimension
+- strongest passage with location and reason
+- weakest passage with location and reason
+- evidence for every score above 8.0
+- blocking defect and smallest viable intervention
+- confidence: low, medium, or high
+- coverage: full manuscript or named sample
+- explicit conflicts of evidence
+
+## Aggregation
+
+1. Calculate median score per dimension.
+2. Use lowest dimension median as floor.
+3. Keep disagreement visible; never hide a weak evaluator behind average enthusiasm.
+4. When evaluator spread reaches 1.5 points on any dimension, dispatch another blind evaluator or mark confidence low.
+5. Apply score calibration only after raw independent reports are frozen.
+6. Apply project threshold only after calibrated scores exist.
+
+## Integrity Failure
+
+Mark evaluation `DEGRADED` when:
+
+- evaluator edited text being scored
+- evaluator saw required target before scoring
+- claims lack textual or structural evidence
+- only excerpts were read but report claims full-manuscript coverage
+- missing output was treated as a passing score
+
+Degraded evaluation can create revision tickets. It cannot approve publication readiness.

--- a/skills/book-genesis/references/scoring/genesis-score-codex.md
+++ b/skills/book-genesis/references/scoring/genesis-score-codex.md
@@ -1,9 +1,11 @@
-# Genesis Score Codex
+# Genesis Score
 
 ## Purpose
 
-Genesis Score Codex is the single scoring contract for `book-genesis-codex`.
+Genesis Score is the single scoring contract for `book-genesis`.
 It must be used consistently across prompts, adapters, examples, reports, and manual review.
+
+Read and follow `evaluator-protocol.md` before scoring. Record the evaluation independence grade in every final report.
 
 The score exists to answer one question:
 
@@ -97,6 +99,7 @@ The score uses 10 dimensions:
 - any score above 8.0 must cite evidence
 - any score above 9.0 must cite multiple pieces of evidence
 - evidence must be textual, structural, or reader-impact based
+- raw blind evaluators do not see writer self-reports, desired pass scores, or previous numeric scores; scorekeeper sees frozen reports and applies thresholds afterward
 - internal scores carry a default +0.8 inflation risk; report calibrated scores when comparing against an external-facing threshold
 - do not let market clarity compensate for literary weakness when the stated goal is critical literary quality
 
@@ -149,5 +152,7 @@ The final report saved to `artifacts/09-genesis-score-codex.md` must include:
 - Weighted Average
 - Literary Barrier Score and threshold when active
 - Gate Verdict
+- Evaluation Independence Grade
+- evaluator disagreement and confidence
 - weakest dimension
 - required intervention or approval note

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,0 +1,168 @@
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from runner.distribution import (  # type: ignore  # noqa: E402
+    BACKUP_DIRECTORY,
+    INSTALL_RECORD,
+    install_suite,
+    resolve_install_root,
+    selected_skills,
+    validate_suite,
+)
+
+
+class DistributionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = Path(tempfile.mkdtemp(prefix="book-genesis-distribution-"))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def test_portable_suite_contract_is_valid(self) -> None:
+        result = validate_suite()
+        self.assertTrue(result["ok"], msg="\n".join(result["errors"]))
+
+    def test_runtime_paths_are_resolved_without_platform_writes(self) -> None:
+        fake_home = self.tempdir / "home"
+        self.assertEqual(
+            (fake_home / ".claude" / "skills").resolve(),
+            resolve_install_root("claude", home=fake_home, environ={}),
+        )
+        self.assertEqual(
+            (fake_home / ".codex" / "skills").resolve(),
+            resolve_install_root("codex", home=fake_home, environ={}),
+        )
+        self.assertEqual(
+            (fake_home / ".kimi-code" / "skills").resolve(),
+            resolve_install_root("kimi", home=fake_home, environ={}),
+        )
+        custom_kimi_home = self.tempdir / "custom-kimi"
+        self.assertEqual(
+            (custom_kimi_home / "skills").resolve(),
+            resolve_install_root(
+                "kimi",
+                home=fake_home,
+                environ={"KIMI_CODE_HOME": str(custom_kimi_home)},
+            ),
+        )
+        self.assertEqual(
+            (fake_home / ".agents" / "skills").resolve(),
+            resolve_install_root("shared", home=fake_home, environ={}),
+        )
+
+    def test_dry_run_does_not_create_destination(self) -> None:
+        destination = self.tempdir / "dry-run-skills"
+        result = install_suite("codex", destination=destination, dry_run=True)
+        self.assertTrue(result["ok"])
+        self.assertFalse(destination.exists())
+        self.assertTrue(any(item["action"] == "install" for item in result["actions"]))
+
+    def test_destination_file_fails_even_in_dry_run(self) -> None:
+        destination = self.tempdir / "not-a-directory"
+        destination.write_text("occupied\n", encoding="utf-8")
+        result = install_suite("codex", destination=destination, dry_run=True)
+        self.assertFalse(result["ok"])
+        self.assertIn("not a directory", result["errors"][0])
+
+    def test_install_copies_same_portable_suite_for_every_runtime(self) -> None:
+        expected = set(selected_skills())
+        for target in ("claude", "codex", "kimi"):
+            destination = self.tempdir / target / "skills"
+            result = install_suite(target, destination=destination)
+            self.assertTrue(result["ok"], msg=str(result["errors"]))
+            installed = {path.name for path in destination.iterdir() if path.is_dir() and not path.name.startswith(".")}
+            self.assertEqual(expected, installed)
+            self.assertTrue((destination / "book-genesis" / "SKILL.md").exists())
+            self.assertFalse((destination / "book-genesis-codex").exists())
+            self.assertTrue((destination / INSTALL_RECORD).exists())
+
+    def test_legacy_profile_is_explicit(self) -> None:
+        destination = self.tempdir / "legacy-dry-run"
+        result = install_suite("claude", destination=destination, include_legacy=True, dry_run=True)
+        actions = {item["skill"] for item in result["actions"]}
+        self.assertIn("book-genesis-codex", actions)
+        self.assertIn("book-genesis-full", actions)
+        legacy_actions = result["legacy_actions"]
+        self.assertTrue(any(item["component"] == "agents" for item in legacy_actions))
+        self.assertTrue(any(item["component"] == "knowledge" for item in legacy_actions))
+
+    def test_legacy_claude_profile_installs_native_agents_only_for_claude(self) -> None:
+        claude_skills = self.tempdir / "claude" / "skills"
+        result = install_suite("claude", destination=claude_skills, include_legacy=True)
+        self.assertTrue(result["ok"], msg=str(result["errors"]))
+        self.assertTrue((self.tempdir / "claude" / "agents" / "book-orchestrator.md").exists())
+        self.assertTrue((self.tempdir / "claude" / "knowledge" / "bestseller-dna.md").exists())
+
+        codex_skills = self.tempdir / "codex" / "skills"
+        codex_result = install_suite("codex", destination=codex_skills, include_legacy=True)
+        self.assertTrue(codex_result["ok"], msg=str(codex_result["errors"]))
+        self.assertEqual([], codex_result["legacy_actions"])
+        self.assertFalse((self.tempdir / "codex" / "agents").exists())
+
+    def test_legacy_agent_conflict_is_backed_up_on_force(self) -> None:
+        claude_skills = self.tempdir / "claude" / "skills"
+        install_suite("claude", destination=claude_skills, include_legacy=True)
+        agent_file = self.tempdir / "claude" / "agents" / "book-orchestrator.md"
+        agent_file.write_text(agent_file.read_text(encoding="utf-8") + "\nlocal agent change\n", encoding="utf-8")
+
+        blocked = install_suite("claude", destination=claude_skills, include_legacy=True)
+        self.assertFalse(blocked["ok"])
+        self.assertIn("agents/book-orchestrator.md", blocked["conflicts"])
+        self.assertIn("local agent change", agent_file.read_text(encoding="utf-8"))
+
+        replaced = install_suite("claude", destination=claude_skills, include_legacy=True, force=True)
+        self.assertTrue(replaced["ok"], msg=str(replaced["errors"]))
+        self.assertNotIn("local agent change", agent_file.read_text(encoding="utf-8"))
+        backups = list(
+            (claude_skills / BACKUP_DIRECTORY).glob("*/agents/book-orchestrator.md")
+        )
+        self.assertEqual(1, len(backups))
+        self.assertIn("local agent change", backups[0].read_text(encoding="utf-8"))
+
+    def test_conflict_requires_force(self) -> None:
+        destination = self.tempdir / "skills"
+        first = install_suite("codex", destination=destination)
+        self.assertTrue(first["ok"])
+        skill_file = destination / "book-genesis" / "SKILL.md"
+        skill_file.write_text(skill_file.read_text(encoding="utf-8") + "\nlocal change\n", encoding="utf-8")
+
+        second = install_suite("codex", destination=destination)
+        self.assertFalse(second["ok"])
+        self.assertIn("book-genesis", second["conflicts"])
+        self.assertIn("local change", skill_file.read_text(encoding="utf-8"))
+
+    def test_force_backs_up_then_replaces_conflict(self) -> None:
+        destination = self.tempdir / "skills"
+        install_suite("kimi", destination=destination)
+        skill_file = destination / "book-genesis" / "SKILL.md"
+        skill_file.write_text(skill_file.read_text(encoding="utf-8") + "\nlocal change\n", encoding="utf-8")
+
+        result = install_suite("kimi", destination=destination, force=True)
+        self.assertTrue(result["ok"], msg=str(result["errors"]))
+        self.assertNotIn("local change", skill_file.read_text(encoding="utf-8"))
+        backup_root = destination / BACKUP_DIRECTORY
+        backups = list(backup_root.glob("*/book-genesis/SKILL.md"))
+        self.assertEqual(1, len(backups))
+        self.assertIn("local change", backups[0].read_text(encoding="utf-8"))
+
+    def test_cli_verifies_suite(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(REPO_ROOT / "runner" / "cli.py"), "verify-suite"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(0, result.returncode, msg=result.stdout + result.stderr)
+        self.assertIn("validation ok", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(REPO_ROOT))
 from runner.filesystem import (  # type: ignore  # noqa: E402
     advance_phase,
     create_demo,
+    fill_outputs_for_demo,
     load_agent_registry,
     load_manifest,
     load_state_summary,
@@ -33,15 +34,16 @@ class RunnerTests(unittest.TestCase):
     def test_manifest_loads_universal_pipeline(self) -> None:
         phases = load_manifest()
         self.assertEqual("Phase 0: Intake", phases[0].label)
-        self.assertEqual("Phase 6: Editorial Package", phases[-1].label)
-        self.assertEqual(7, len(phases))
+        self.assertEqual("Phase 7: Editorial Package", phases[-1].label)
+        self.assertEqual(8, len(phases))
+        self.assertEqual("Phase 5: Literary Barrier Revision Loop", phases[5].label)
 
     def test_market_level_skills_are_packaged(self) -> None:
         bestseller = REPO_ROOT / "skills" / "book-bestseller-studio" / "SKILL.md"
         swarm = REPO_ROOT / "skills" / "book-swarm-panel" / "SKILL.md"
         self.assertTrue(bestseller.exists())
         self.assertTrue(swarm.exists())
-        self.assertIn("book-genesis-codex", bestseller.read_text(encoding="utf-8"))
+        self.assertIn("canonical `book-genesis`", bestseller.read_text(encoding="utf-8"))
         self.assertIn("MiroFish", swarm.read_text(encoding="utf-8"))
 
     def test_agent_registry_loads_bestseller_team(self) -> None:
@@ -52,6 +54,7 @@ class RunnerTests(unittest.TestCase):
         self.assertIn("pacing_engineer", keys)
         self.assertIn("viral_framing_strategist", keys)
         self.assertIn("scorekeeper", keys)
+        self.assertIn("blind_literary_critic", keys)
         self.assertGreaterEqual(len(agents), 12)
 
     def test_init_creates_project_contract(self) -> None:
@@ -72,6 +75,9 @@ class RunnerTests(unittest.TestCase):
         summary = load_state_summary(self.tempdir)
         self.assertEqual("codex", summary["adapter"])
         self.assertEqual("Phase 0: Intake", summary["current_phase"])
+        state = (self.tempdir / "PROJECT_STATE.yaml").read_text(encoding="utf-8")
+        self.assertIn("target_floor_words: 0", state)
+        self.assertIn('length_gate: "pending"', state)
 
     def test_validate_checks_required_files(self) -> None:
         scaffold_project(self.tempdir, idea="", adapter="codex", model_name="gpt-5.5")
@@ -87,6 +93,17 @@ class RunnerTests(unittest.TestCase):
         self.assertIn("references/prompts/intake.md", packet)
         self.assertIn("ASSUMPTIONS.md", packet)
         self.assertIn("Phase Prompt", packet)
+
+    def test_literary_phase_packet_embeds_evaluator_protocol(self) -> None:
+        scaffold_project(self.tempdir, idea="", adapter="codex", model_name="gpt-5.5")
+        for phase in load_manifest()[:5]:
+            fill_outputs_for_demo(self.tempdir, phase)
+            result = advance_phase(self.tempdir)
+            self.assertTrue(result["ok"])
+        packet = prepare_phase(self.tempdir).read_text(encoding="utf-8")
+        self.assertIn("Phase 5: Literary Barrier Revision Loop", packet)
+        self.assertIn("Required Reference: references/scoring/evaluator-protocol.md", packet)
+        self.assertIn("Independence Grades", packet)
 
     def test_prepare_swarm_run_creates_mirofish_bridge_contract(self) -> None:
         scaffold_project(self.tempdir, idea="", adapter="codex", model_name="gpt-5.5")
@@ -113,6 +130,14 @@ class RunnerTests(unittest.TestCase):
         self.assertIn("8.5 pacing/opening target", packet)
         self.assertIn("artifacts/05-outline.md", packet)
         self.assertIn("skills/prose-craft/SKILL.md", packet)
+
+    def test_blind_critic_packet_hides_threshold(self) -> None:
+        scaffold_project(self.tempdir, idea="", adapter="codex", model_name="gpt-5.5")
+        packet = prepare_agent_packet(self.tempdir, "blind_literary_critic").read_text(encoding="utf-8")
+        self.assertIn("Blind evaluation: yes", packet)
+        self.assertIn("Score floor: withheld from blind evaluator", packet)
+        self.assertNotIn("8.5", packet)
+        self.assertIn("previous scores", packet)
 
     def test_advance_blocks_unfilled_templates(self) -> None:
         scaffold_project(self.tempdir, idea="seed idea", adapter="codex", model_name="gpt-5.5")
@@ -142,6 +167,20 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual("completed", summary["status"])
         self.assertTrue((self.tempdir / "manuscript" / "chapters" / "chapter-01.md").exists())
         self.assertIn("mechanical demo", (self.tempdir / "RUN_REPORT.md").read_text(encoding="utf-8"))
+
+    def test_independent_evaluator_protocol_is_packaged(self) -> None:
+        protocol = (
+            REPO_ROOT
+            / "skills"
+            / "book-genesis"
+            / "references"
+            / "scoring"
+            / "evaluator-protocol.md"
+        )
+        self.assertTrue(protocol.exists())
+        text = protocol.read_text(encoding="utf-8")
+        self.assertIn("Independence Grades", text)
+        self.assertIn("Grade C is diagnostic only", text)
 
     def test_cli_init_runs_by_path(self) -> None:
         project = self.tempdir / "cli-project"

--- a/video-demo/src/Scene6CTA.tsx
+++ b/video-demo/src/Scene6CTA.tsx
@@ -114,7 +114,7 @@ export const Scene6CTA: React.FC = () => {
                 letterSpacing: '0.02em',
               }}
             >
-              github.com/felipelobomotta-blip/best-seller-studio
+              github.com/felipelobomotta-blip/book-genesis-v4
             </span>
           </div>
         </div>

--- a/web/landing.html
+++ b/web/landing.html
@@ -293,7 +293,7 @@
     <p class="lede" data-lang-pt>Um pipeline de produção de livros com IA, agnóstico de agente. Leve uma ideia de uma linha por pesquisa, escrita, auditoria adversarial, pontuação e empacotamento editorial — no Claude Code, Codex, Antigravity, Kimi ou qualquer agente que enxergue arquivos.</p>
 
     <div class="ctas">
-      <a class="btn btn-primary" href="https://github.com/felipelobomotta-blip/best-seller-studio" target="_blank" rel="noopener">
+      <a class="btn btn-primary" href="https://github.com/felipelobomotta-blip/book-genesis-v4" target="_blank" rel="noopener">
         <span data-lang-en>Open on GitHub →</span>
         <span data-lang-pt>Abrir no GitHub →</span>
       </a>
@@ -571,7 +571,7 @@
     <p class="quote" data-lang-en>Built for writers who want to <em>run the loop,</em><br>not babysit it.</p>
     <p class="quote" data-lang-pt>Feito pra escritores que querem <em>rodar o loop,</em><br>não vigiar ele.</p>
     <div class="ctas" style="justify-content: center;">
-      <a class="btn btn-primary" href="https://github.com/felipelobomotta-blip/best-seller-studio" target="_blank" rel="noopener">
+      <a class="btn btn-primary" href="https://github.com/felipelobomotta-blip/book-genesis-v4" target="_blank" rel="noopener">
         <span data-lang-en>Star on GitHub</span>
         <span data-lang-pt>Estrelar no GitHub</span>
       </a>
@@ -583,7 +583,7 @@
   <div class="container">
     <span data-lang-en>MIT licensed · </span>
     <span data-lang-pt>Licença MIT · </span>
-    <a href="https://github.com/felipelobomotta-blip/best-seller-studio" target="_blank" rel="noopener">github.com/felipelobomotta-blip/best-seller-studio</a>
+    <a href="https://github.com/felipelobomotta-blip/book-genesis-v4" target="_blank" rel="noopener">github.com/felipelobomotta-blip/book-genesis-v4</a>
   </div>
 </footer>
 


### PR DESCRIPTION
Adds portable Claude/Codex/Kimi skill runtime, blind literary evaluation protocol, installer safety, docs, and tests. Validation: python -m unittest discover -s tests -v; python runner\\cli.py verify-suite; git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a portable installation workflow for Claude Code, Codex, Kimi Code, and shared skill directories.
  * Added suite verification, dry-run previews, destination customization, conflict detection, backups, checksums, and optional legacy components.
  * Introduced independent evaluator safeguards, blind literary review, and strengthened quality-gated revision and scoring.

* **Documentation**
  * Updated setup, portability, contribution, workflow, and runtime guidance for the universal pipeline.
  * Refreshed repository links and launch materials across documentation, website, and promotional assets.

* **Tests**
  * Added coverage for installation safety, portability, evaluator isolation, and pipeline integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->