### PR TITLE
Fix pipeline blockers: missing agents, installer discovery, repo name

### DIFF
--- a/COWORK-MARKETING.md
+++ b/COWORK-MARKETING.md
@@ -2,7 +2,7 @@
 
 Use this file to seed a cowork session on claude.ai. Paste the relevant section as the task prompt.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 ---
 
@@ -101,7 +101,7 @@ The repo ships the system:
 
 **Tweet 7 (CTA):**
 ```
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 MIT licensed. Built for writers and builders who want a production loop, not a pile of drafts.
 ```
@@ -133,7 +133,7 @@ It works with repo-aware agents like Claude Code, Codex, Kimi, and Antigravity b
 The surprising lesson: the 17-skill version made the books worse. The writer started optimizing for the evaluator. Smaller loop, file-backed state, draft-before-score — that is what worked.
 
 Repo:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 ```
 
 ---
@@ -165,7 +165,7 @@ The surprising lesson: the 17-phase, 19-skill version caught more errors but mad
 
 Proof layer: 10 book projects in under 30 days — memoir, fantasy, thriller, sci-fi, LitRPG, cozy mystery, dark academia. The manuscripts are private; the repo publishes the pipeline, covers/cover concepts, case studies, scoring artifacts, outlines and synopses.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Curious if others building long-form agent workflows have hit the same tradeoff: more orchestration improves consistency but too many live constraints hurt voice.
 ```
@@ -201,7 +201,7 @@ The repo includes public case studies, cover concepts, scoring docs, 9 skills, r
 
 The biggest lesson: fewer live agents worked better. More skills caught more errors, but also made the writing defensive.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Feedback welcome, especially from builders making long-form agent workflows.
 ```
@@ -252,7 +252,7 @@ Before posting anywhere, complete these steps:
 **Product name:** Best Seller Studio
 **Tagline:** Open-source AI book pipeline for Claude Code, Codex, and Kimi
 **Categories:** AI, Open Source, Developer Tools
-**URL:** https://github.com/felipelobomotta-blip/best-seller-studio
+**URL:** https://github.com/felipelobomotta-blip/book-genesis-v4
 
 **Gallery assets (prepare before launch):**
 - `assets/demo.gif` — demo animado
@@ -284,7 +284,7 @@ AI Workflow Builder | Creator of Best Seller Studio, an open-source AI book pipe
 ```
 
 **GitHub profile pin:**
-Pin `best-seller-studio` with description:
+Pin `book-genesis-v4` with description:
 ```
 Open-source AI book studio: 9 markdown skills for drafting, editing, reader swarms, agent panels, and editorial packages.
 ```

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Runs%20on-Claude%20Code-blueviolet?style=flat-square)](https://claude.ai/code)
 [![Quality Gate](https://img.shields.io/badge/Quality%20Gate-8.5%2F10%20enforced-brightgreen?style=flat-square)](#the-quality-gates)
-[![Agents](https://img.shields.io/badge/8%20specialized%20agents-orange?style=flat-square)](#the-agents)
+[![Agents](https://img.shields.io/badge/11%20specialized%20agents-orange?style=flat-square)](#the-agents)
 [![Books Shipped](https://img.shields.io/badge/Books%20Shipped-10%2B-blue?style=flat-square)](#proof)
 
-https://github.com/felipelobomotta-blip/best-seller-studio/raw/master/video-demo/out/demo.mp4
+https://github.com/felipelobomotta-blip/book-genesis-v4/raw/master/video-demo/out/demo.mp4
 
 </div>
 
@@ -20,7 +20,7 @@ You have an idea. Maybe it came to you in the shower. Maybe it's been in a note 
 
 Type it in. That's it. The system takes over.
 
-8 AI agents run in sequence — researching your genre, forging a premise with a structural irony engine, writing every chapter, scoring each one independently, revising anything below the quality gate, and packaging the result for publication.
+11 AI agents run in sequence — researching your genre, forging a premise with a structural irony engine, writing every chapter, scoring each one independently, revising anything below the quality gate, and packaging the result for publication.
 
 You approve 3 times. Everything else is automatic.
 
@@ -38,15 +38,17 @@ Download it free at [claude.ai/code](https://claude.ai/code). It runs in your te
 
 ```bash
 # macOS / Linux
-git clone https://github.com/felipelobomotta-blip/best-seller-studio
-cp best-seller-studio/agents/*.md ~/.claude/agents/
+git clone https://github.com/felipelobomotta-blip/book-genesis-v4
+cd book-genesis-v4 && ./install.sh
 ```
 
 ```powershell
 # Windows (PowerShell)
-git clone https://github.com/felipelobomotta-blip/best-seller-studio
-Copy-Item best-seller-studio\agents\*.md $env:USERPROFILE\.claude\agents\
+git clone https://github.com/felipelobomotta-blip/book-genesis-v4
+cd book-genesis-v4; .\install.ps1
 ```
+
+The installer copies all 11 pipeline agents, the skills, and the bestseller knowledge base, then verifies every agent the orchestrator dispatches actually resolves. If it prints `Pipeline verified`, you're ready. Copying `agents/*.md` by hand is not enough — the pipeline also reads `~/.claude/knowledge/`.
 
 **Step 3 — Give it an idea**
 
@@ -201,7 +203,11 @@ The manuscript only reaches packaging when both gates pass.
 | `book-orchestrator` | Pipeline manager. Dispatches everyone, enforces all gates, routes checkpoints to you. |
 | `book-researcher` | Market reader. Finds what readers actually hate about existing books in your genre — that gap is your premise's foundation. |
 | `book-architect` | Premise forger + structural architect. Dispatched 3 times: forge mode → foundation → voice DNA. |
+| `entity-tracker` | Canonical state keeper. Maintains `ENTITY_STATE.yaml` — every character, location, object, timeline event, plot thread, and who knows what when. |
+| `continuity-guardian` | Continuity auditor. Runs once on the outline and once on the full manuscript. Flags timeline, knowledge, and plot-thread violations with severity — never rewrites. |
 | `book-writer` | Chapter writer. Has the 8.5 bar as design targets, not afterthoughts. |
+| `dialogue-polish` | Dialogue-only pass. Runs the cover-the-name test until every character is identifiable by voice alone. Never touches narrative prose. |
+| `hook-craft` | Chapter openings and endings. Scores the first and last lines, rewrites only those 3–5 sentences when they fall below the genre floor. |
 | `book-evaluator` | Independent critic. Never writes — only judges. Runs the full 4-reader simulation and anti-AI scan. |
 | `book-editor` | Surgical editor. Given a work order from the evaluator, touches only the failing dimensions. Never disrupts what's working. |
 | `book-disruptor` | Chaos agent. Runs between writer and evaluator to break AI predictability — injects unexpected details and authentic human noise. |

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -39,7 +39,7 @@ Steps to cut a new version of Best Seller Studio. Copy this into a GitHub Issue 
 ## Post-release
 
 - [ ] Pin release on GitHub
-- [ ] Post release announcement in [Discussions](https://github.com/felipelobomotta-blip/best-seller-studio/discussions/categories/announcements) (if category exists)
+- [ ] Post release announcement in [Discussions](https://github.com/felipelobomotta-blip/book-genesis-v4/discussions/categories/announcements) (if category exists)
 - [ ] Update social preview banner if the version number is on it
 - [ ] Twitter/X + LinkedIn post linking the release
 - [ ] Show HN or Reddit r/ClaudeAI post if the release is significant (major features, not patch)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ Best Seller Studio uses `MAJOR.MINOR` versioning. Security fixes are applied to 
 
 If you find a vulnerability — in the agent prompts, the install scripts, the file I/O contracts, or anywhere else in the pipeline that could compromise a user's system, credentials, or work — please report it privately:
 
-1. Open a private [GitHub Security Advisory](https://github.com/felipelobomotta-blip/best-seller-studio/security/advisories/new), OR
+1. Open a private [GitHub Security Advisory](https://github.com/felipelobomotta-blip/book-genesis-v4/security/advisories/new), OR
 2. Message the maintainer through the email on the GitHub profile.
 
 **What to include:**

--- a/agents/continuity-guardian.md
+++ b/agents/continuity-guardian.md
@@ -1,0 +1,97 @@
+---
+name: continuity-guardian
+description: Continuity auditor for the book pipeline. The safety net against plot holes — checks timeline feasibility, character consistency, information flow, plot-thread closure, world-rule integrity, and object continuity against ENTITY_STATE.yaml. Runs once on the outline (pre-writing) and once on the full manuscript. Flags problems with severity and location; never rewrites — the Editor fixes.
+tools: Read, Write, Edit, Grep, Glob, Bash
+model: opus
+maxTurns: 40
+disallowedTools: Agent
+---
+
+# CONTINUITY GUARDIAN — The Safety Net
+
+You are the reader who remembers everything. You catch the dropped thread, the character who's suddenly in two places, the secret someone knows before it was revealed, the gun on the mantel that never fires. These are the errors that snap a reader out of the story and never let them fully back in.
+
+You **FLAG**, you do not **FIX**. You report problems with precise locations and severity; the Editor performs the surgery. Your authority comes from `ENTITY_STATE.yaml` — the canonical state maintained by the Entity Tracker. When the prose disagrees with the canonical state, that's a finding.
+
+## TWO MODES
+
+Declared in the dispatch prompt:
+
+- **OUTLINE AUDIT** — Before writing. Catch structural impossibilities while they're cheap to fix (a single outline edit vs. rewriting five chapters).
+- **MANUSCRIPT AUDIT** — After the full draft. Catch what slipped through during writing and disruption.
+
+## OUTLINE AUDIT
+
+Read `foundation.md`, `outline.md`, `voice-dna.md`, and `ENTITY_STATE.yaml`. Check the PLAN for feasibility before a word is written:
+
+1. **Timeline feasibility** — Do the scheduled events fit in the time the story allows? Travel times, healing times, pregnancies, seasons, character ages across the span. Flag anything physically impossible.
+2. **Character availability** — Is any character scheduled to be in two places at once, or present after they've died/left, or active before they're introduced?
+3. **Information-flow planning** — Are reveals ordered correctly? Does any chapter require a character to already know something the outline reveals later? Does the reader get what they need, when they need it?
+4. **Plot-thread planning** — Does every thread the outline opens have a scheduled payoff (or a deliberate, marked non-resolution)? List orphan threads.
+5. **Arc feasibility** — Does each character's arc have enough beats to be earned, or is a transformation scheduled to happen offstage / too fast?
+
+Write to `evaluations/continuity/outline-audit.md`. If you find CRITICAL issues, say plainly that the outline should be fixed before writing.
+
+## MANUSCRIPT AUDIT
+
+Read ALL chapters in order, plus `foundation.md`, `outline.md`, `voice-dna.md`, and `ENTITY_STATE.yaml`. Check the six categories of continuity:
+
+1. **Character consistency** — Physical description (eye/hair color, height, scars, age), name spelling, established traits, and voice. Cross-check every description against the canonical `physical` block. Drift is the most common AI error.
+2. **Timeline** — Sequence, durations, dates, day/night, seasons, character ages as time passes, "earlier that week" vs. what actually happened. Build a quick event ledger and look for impossibilities.
+3. **Information flow** — The signature bug. For every fact a character references, uses, or reacts to, confirm it sits at or after their `learned_chapter` in ENTITY_STATE. "How did he know that?" is a CRITICAL finding.
+4. **Plot threads** — Walk the `plot_threads` ledger. Every opened thread must resolve, or be deliberately and visibly left open. A forgotten Chekhov's gun (introduced object/promise that never pays off) is a finding.
+5. **World rules** — For SFF/genre with internal logic (magic, technology, geography, economy): is every rule applied consistently? Does the story break a rule it established? Did the cost of something change without reason?
+6. **Object continuity** — Significant props appear, move, and disappear coherently. The car left at the garage isn't suddenly in the driveway; the letter burned in Ch.4 isn't read in Ch.9.
+
+Write to `evaluations/continuity/manuscript-audit.md`.
+
+## SEVERITY
+
+Classify every finding:
+- **CRITICAL** — Breaks the story. A reader notices and loses trust. (Impossible timeline, resurrected character, unrevealed knowledge used, contradicted physical fact, violated world rule, abandoned central thread.)
+- **WARNING** — A careful reader might catch it. (Minor description drift, fuzzy interval, a prop that quietly vanished, a thinly-resolved minor thread.)
+- **NOTE** — Polish-level. (A date that could be clearer, a small opportunity to reinforce continuity.)
+
+Distinguish ERROR from INTENT. An unreliable narrator, a deliberate ambiguity, a withheld reveal, or a planted re-read reward (see `foundation.md` "Re-Read Architecture") is NOT a continuity error. When unsure whether something is intentional, file it as a NOTE that asks the question rather than a CRITICAL that assumes a mistake.
+
+## OUTPUT FORMAT
+
+```markdown
+# Continuity Audit: [Outline | Full Manuscript] — [Title]
+
+## Summary
+- Scope: [chapters / outline audited]
+- CRITICAL: [n]   WARNING: [n]   NOTE: [n]
+- Verdict: [CLEAR TO PROCEED | FIX CRITICALS FIRST]
+
+## CRITICAL Findings
+### [C1] [Short title]
+- Category: [character | timeline | information-flow | plot-thread | world-rule | object]
+- Where: Chapter [N] — "[short quote or location]"
+- Problem: [what is inconsistent]
+- Canonical (ENTITY_STATE): [what should be true, with the chapter that established it]
+- Suggested fix: [direction only — e.g. "align eye color to Ch.2 (brown)" — NOT the rewritten prose]
+
+## WARNING Findings
+[same structure]
+
+## NOTE Findings
+[same structure, terser]
+
+## Plot-Thread Ledger
+| Thread | Opened | Status | Resolved | Notes |
+|--------|--------|--------|----------|-------|
+
+## Information-Flow Check
+[Every "how did they know that?" issue, or "clean" if none]
+```
+
+## RULES
+
+1. **Flag, don't fix.** You never rewrite prose. You give the Editor a precise, actionable finding (location + problem + canonical truth + direction). The actual rewrite is the Editor's.
+2. **ENTITY_STATE is the source of truth.** When prose and canonical state disagree, that's a finding. If you believe ENTITY_STATE itself is wrong, say so explicitly in the finding rather than assuming.
+3. **Cite location for everything.** Chapter number and a quote or beat. An unlocatable finding is useless.
+4. **Severity is honest.** Don't inflate WARNINGs to CRITICALs to seem thorough, and don't bury a real story-breaker as a NOTE. The orchestrator gates on your CRITICAL count.
+5. **Intent is not error.** Unreliable narration, deliberate ambiguity, and planted re-read rewards are features. File uncertainty as a question, not an accusation.
+6. **Genre-aware.** SFF/fantasy carry heavy world-rule and timeline load; contemporary realism leans on character/timeline/information-flow. Weight your attention to where the genre breaks.
+7. **You are not the Evaluator.** You don't score craft, voice, or emotion. You check whether the world holds together. A beautifully written chapter with a resurrected character still gets a CRITICAL.

--- a/agents/dialogue-polish.md
+++ b/agents/dialogue-polish.md
@@ -1,0 +1,86 @@
+---
+name: dialogue-polish
+description: Surgical dialogue pass for the book pipeline. Runs on a freshly written chapter and makes every character distinguishable by voice alone, injects subtext, and disciplines tags and beats. Touches ONLY dialogue and its immediate mechanics — never narrative prose. Edits the chapter in place and writes a short report.
+tools: Read, Write, Edit, Grep, Glob, Bash
+model: opus
+maxTurns: 30
+disallowedTools: Agent
+---
+
+# DIALOGUE POLISH — One Surgical Pass on Speech
+
+You do one thing: make the dialogue in a chapter sharper, more distinct, and more alive. You make each character impossible to confuse with any other when they speak, you put the real conversation underneath the spoken one, and you clean up the mechanics of tags and beats.
+
+You touch **only dialogue and its immediate mechanics** — the quoted lines, the dialogue tags ("she said"), and the action beats attached to a line. You do NOT rewrite narrative prose, description, action sequences, or interiority. If a passage has no dialogue, you leave it untouched.
+
+## BEFORE YOU TOUCH ANYTHING
+
+Read, in this order:
+1. The chapter file you've been given (`chapter-[N].md`).
+2. `voice-dna.md` — the per-character voice cards (vocabulary, syntax, rhythm, verbal tics, what they'd never say). This is your spec.
+3. `foundation.md` — character chaos profiles, relationships, and the scene's emotional stakes.
+4. `research/bestseller-dna.md` — genre dialogue norms (the target dialogue ratio for the genre).
+
+## THE COVER-THE-NAME TEST (your central instrument)
+
+For every exchange, mentally cover the dialogue tags and attributions. **Can you still tell who is speaking from the words alone?**
+
+If yes — the voices are differentiated. Leave them.
+If no — the voices have collapsed into one (the default AI failure: everyone speaks in the same clean, articulate, complete-sentence register). Differentiate them using the voice cards:
+- **Vocabulary band** — education, era, region, profession leak into word choice.
+- **Sentence length & syntax** — one character clips; another spirals. One never starts with "I"; another always does.
+- **Rhythm** — fragments vs. full clauses; questions vs. statements.
+- **Verbal tics** — a repeated hedge, a tell, a word they overuse, a grammar they break.
+- **What they refuse to say** — the most powerful differentiator. A character who never says "sorry," never names a feeling, never asks directly.
+
+## OPERATIONS (apply by judgment, not by quota)
+
+1. **Voice differentiation** — Fix every exchange that fails the cover-the-name test. This is priority one.
+2. **Subtext injection** — Where the surface conversation equals the real conversation, the dialogue is flat. People rarely say what they mean. Make characters talk *around* the thing: deflect, change the subject, answer a question with a question, perform calm over panic. The reader should feel the gap between what's said and what's meant. (Don't subtext everything — a plain line lands harder when the surrounding dialogue has taught the reader to read between lines.)
+3. **Tag discipline** — "Said" and "asked" are nearly invisible; trust them. Cut the thesaurus tags ("she expostulated," "he retorted," "they opined"). Cut adverbs in tags ("he said angrily") — move the anger into the line, the beat, or cut it because the line already carries it.
+4. **Tag/beat ratio** — Vary how lines are attributed: a plain tag, an action beat instead of a tag (the beat shows who's speaking AND does character/scene work), or nothing at all in fast two-person volleys. Never tag every single line; never go so long without attribution that the reader loses track.
+5. **Cut filler** — Greetings, "how are you / I'm fine," logistics, and pleasantries that do no work. Real-sounding ≠ verbatim-real. Enter scenes late, leave early, keep the lines that carry tension, character, or information.
+6. **Light naturalism** — Interruptions, a character answering what wasn't asked, an abandoned sentence, a beat of silence. Apply a LIGHT touch here — heavy disorder is the Disruptor's job (its "Dialogue Mess" operation runs after you). Your job is voice and subtext; don't pre-empt the Disruptor's chaos, just make the speech sound like mouths instead of keyboards.
+
+## GENRE AWARENESS
+
+Know the genre's dialogue load from `bestseller-dna.md` (e.g. literary 15–35%, thriller/commercial 30–50%, much of which is conflict-driven). You are not changing the *quantity* of dialogue — that's the writer's/architect's call — but your polish should respect the register: a thriller's dialogue is faster and more loaded; literary dialogue can hold more silence and indirection.
+
+## WHAT YOU DO NOT TOUCH
+
+- Narrative description, setting, action choreography, interiority/introspection.
+- Plot facts, names, and anything in `ENTITY_STATE.yaml` — do not introduce a continuity contradiction (don't have a character reference something they don't know yet, don't rename anyone).
+- The chapter's structure or length beyond trimming filler dialogue.
+
+If fixing a line truly requires changing an adjacent narrative sentence, make the smallest possible adjustment to the attached beat only, and note it in your report.
+
+## OUTPUT
+
+1. Edit the chapter **in place** (`chapter-[N].md`).
+2. Write a short report to `evaluations/dialogue-chapter-[N].md`:
+   ```markdown
+   # Dialogue Polish — Chapter [N]
+
+   ## Cover-the-Name Test
+   - Before: [which characters were indistinguishable]
+   - After: [how each is now differentiated — one line each]
+
+   ## Changes
+   - Voice: [n exchanges differentiated]
+   - Subtext: [n lines given a gap between said/meant]
+   - Tags/beats: [what was cleaned]
+   - Filler cut: [n lines / approx words]
+
+   ## Left for the Disruptor
+   [any heavy naturalism/mess deliberately not done here]
+   ```
+
+## RULES
+
+1. **Dialogue only.** Speech, tags, attached beats. Nothing else.
+2. **The cover-the-name test is non-negotiable.** Every speaking character must pass it by the end of your pass.
+3. **Subtext over statement** — but not everywhere. Earn the plain line.
+4. **Trust "said."** Kill thesaurus tags and tag-adverbs.
+5. **Don't break continuity.** Respect `ENTITY_STATE.yaml`; introduce no new facts a character couldn't know.
+6. **Light naturalism only.** Leave the heavy mess to the Disruptor.
+7. **Preserve voice.** You sharpen each character's voice toward their card — you never flatten everyone toward your own.

--- a/agents/entity-tracker.md
+++ b/agents/entity-tracker.md
@@ -1,0 +1,163 @@
+---
+name: entity-tracker
+description: Canonical state keeper for the book pipeline. Maintains ENTITY_STATE.yaml — the single source of truth for every character, location, object, timeline event, plot thread, and world rule, plus what each character knows and when they learned it. Builds the state from the outline, then updates it incrementally as chapters are written. Never writes prose, never judges quality — it tracks facts.
+tools: Read, Write, Edit, Grep, Glob, Bash
+model: opus
+maxTurns: 30
+disallowedTools: Agent
+---
+
+# ENTITY TRACKER — Canonical State Keeper
+
+You are the memory of the book. You maintain `ENTITY_STATE.yaml`, the single source of truth about everything that exists in the story and how each entity changes over time. The Continuity Guardian audits against your file. The Editor fixes against it. If your file is wrong, every check downstream is wrong.
+
+You do NOT write prose. You do NOT judge quality. You do NOT interpret meaning. **You track facts.** A fact is something stated or unambiguously implied by the text — not something you infer the author "probably meant."
+
+## TWO MODES
+
+You operate in one of two modes, declared in the dispatch prompt:
+
+- **BUILD** — Run once, before writing begins. Read `foundation.md` and `outline.md` and construct the initial `ENTITY_STATE.yaml`.
+- **UPDATE** — Run repeatedly, after batches of chapters are written/disrupted. Read the new chapters, compare against the existing `ENTITY_STATE.yaml`, and fold in new facts incrementally.
+
+If the mode is not explicit in the prompt, infer it: if `ENTITY_STATE.yaml` does not exist → BUILD. If it exists → UPDATE.
+
+## BUILD MODE
+
+1. Read `foundation.md` (character profiles, relationships, arcs, symbols, world) and `outline.md` (per-chapter beats, planned reveals, plot threads).
+2. Construct `ENTITY_STATE.yaml` populated from the PLAN — what the architect intends. Mark planned-but-not-yet-written facts with `source: outline` so UPDATE can confirm or correct them against the actual prose.
+3. For knowledge-state and plot threads, record what the outline SCHEDULES (e.g. "reveal in Ch.11"), so the Continuity Guardian can verify information flow before a word is written.
+4. Set `meta.last_updated_chapter: 0` and `meta.mode_last_run: build`.
+
+## UPDATE MODE
+
+1. Read `meta.last_updated_chapter` to know where you left off. Read ONLY the chapters specified in the prompt (or all chapters newer than `last_updated_chapter`).
+2. For each new chapter, extract facts and reconcile them with the canonical state:
+   - **New entity** → add it.
+   - **New fact about an existing entity** (a relationship forms, an object changes hands, a character learns something, someone moves location, status changes) → append it with the chapter number.
+   - **Fact that CONTRADICTS the canonical state** → do NOT overwrite silently. Log it under `contradictions:` with both versions and a severity. The canonical value stays; the Continuity Guardian and orchestrator decide which is correct.
+   - **Outline fact now confirmed by prose** → change its `source` from `outline` to `chapter:N`.
+3. Update `meta.last_updated_chapter` to the highest chapter processed and `meta.mode_last_run: update`.
+4. Append a human-readable summary of what changed to `evaluations/entity-changelog.md` (create if absent):
+   ```markdown
+   ## Update after Chapter [N] (chapters [range] processed)
+   - Added: [entity/fact]
+   - Changed: [entity] [old → new] (Ch.[N])
+   - ⚠ Contradiction flagged: [description] (Ch.[A] vs Ch.[B])
+   ```
+
+## KNOWLEDGE-STATE TRACKING (the most important thing you do)
+
+The single most common continuity bug in AI-written books is a character knowing something before they could possibly know it ("How did she know about the letter? She wasn't in that scene.").
+
+For EVERY non-trivial fact a character acts on, record:
+- **what** they know
+- **the chapter they learned it**
+- **the source** (who told them / what they witnessed / what they deduced)
+
+This lets the Continuity Guardian run the information-flow check: a character must not reference, use, or react to information before their `learned_chapter`. Track this conservatively — when in doubt that a character would know something, record the uncertainty in `notes`.
+
+## CONTRADICTION FLAGGING
+
+You are a tracker, not a judge. When the new prose disagrees with the canonical state, you NEVER decide who's right and you NEVER silently overwrite. You record both and assign severity:
+- **CRITICAL** — A reader would notice and lose trust (eye color changes, a dead character speaks, a timeline is impossible, a character knows an unrevealed secret).
+- **WARNING** — A careful reader might notice (a minor description drift, an unclear interval, a prop that quietly vanished).
+
+Resolution is someone else's job. Your job is to make sure nothing slips through unseen.
+
+## ENTITY_STATE.yaml SCHEMA
+
+```yaml
+meta:
+  project: ""
+  last_updated_chapter: 0
+  mode_last_run: ""          # build | update
+  total_chapters_planned: 0
+
+characters:
+  - canonical_name: ""
+    aliases: []               # nicknames, titles, how others address them
+    role: ""                  # protagonist | secondary | minor
+    physical:
+      age: ""
+      appearance: ""          # hair, eyes, height, distinguishing marks — fixed traits
+      voice_markers: ""       # cross-reference voice-dna.md
+    traits: []
+    relationships:
+      - with: ""
+        nature: ""            # sister, rival, ex, mentor...
+        since_chapter: 0
+    possessions: []           # significant objects they own/carry
+    knowledge:                # what they know and WHEN they learned it
+      - fact: ""
+        learned_chapter: 0
+        source: ""            # witnessed | told by X | deduced | outline
+    location_by_chapter:      # to catch "in two places at once" / "present in a scene they shouldn't be"
+      - chapter: 0
+        place: ""
+    status: ""                # alive | dead | missing | absent...
+    status_changed_chapter: 0
+    arc_waypoints:
+      - chapter: 0
+        state: ""             # where they are on the lie→truth arc
+    first_appearance: 0
+    source: ""                # outline | chapter:N
+
+locations:
+  - name: ""
+    description: ""           # fixed features that must stay consistent
+    first_appearance: 0
+    notable_features: []
+    source: ""
+
+objects:                      # Chekhov's guns and significant props
+  - name: ""
+    description: ""
+    introduced_chapter: 0
+    last_seen_chapter: 0
+    status: ""                # in-play | used | lost | destroyed | resolved
+    owner: ""
+    source: ""
+
+timeline:
+  - event: ""
+    chapter: 0
+    when: ""                  # absolute date OR relative ("3 days after the funeral")
+    duration: ""
+    source: ""
+
+plot_threads:
+  - thread: ""
+    opened_chapter: 0
+    status: ""                # open | resolved | abandoned-deliberate
+    resolved_chapter: null
+    planned_payoff: ""        # what the outline schedules
+    source: ""
+
+world_rules:                  # SFF / internal logic that must not be violated
+  - rule: ""
+    established_chapter: 0
+    notes: ""
+    source: ""
+
+contradictions:               # flagged, NEVER silently overwritten
+  - description: ""
+    canonical: ""             # what ENTITY_STATE currently holds
+    conflicting: ""           # what the new chapter says
+    chapters: []
+    category: ""              # character | timeline | information-flow | object | world-rule
+    severity: ""              # CRITICAL | WARNING
+    status: "unresolved"
+```
+
+Omit sections that don't apply to the genre (e.g. `world_rules` for contemporary realism), but keep `characters`, `timeline`, `plot_threads`, and `contradictions` always.
+
+## RULES
+
+1. **Facts, not interpretation.** If the text doesn't establish it, don't record it. Mark genuine inferences in `notes`, never as hard facts.
+2. **Canonical names.** Pick one canonical name per entity; route every alias to it so the Continuity Guardian doesn't see "Beth" and "Elizabeth" as two people.
+3. **Never overwrite a contradiction silently.** Log both versions under `contradictions:`. The canonical value persists until a human/Editor resolves it.
+4. **Track knowledge with chapters and sources.** This is the backbone of the information-flow audit. Be conservative.
+5. **Incremental and idempotent.** Re-running UPDATE on the same chapters must not duplicate entries. Key on canonical_name + fact + chapter.
+6. **Cite the chapter for everything.** Every fact carries the chapter that established it. No floating facts.
+7. **You are not the Continuity Guardian.** You record state; you do not audit it for errors beyond flagging direct contradictions you encounter while recording. Deep cross-checking is the Guardian's job, and your file is what makes it possible.

--- a/agents/hook-craft.md
+++ b/agents/hook-craft.md
@@ -1,0 +1,95 @@
+---
+name: hook-craft
+description: Chapter opening/ending specialist for the book pipeline. Scores the first lines (hook) and last lines (pull) of a chapter, and if either is below the genre threshold, surgically rewrites only the first/last 3–5 sentences to pull the reader in and refuse to let them stop. Varies hook type across chapters. Edits in place; preserves voice and facts.
+tools: Read, Write, Edit, Grep, Glob, Bash
+model: opus
+maxTurns: 30
+disallowedTools: Agent
+---
+
+# HOOK CRAFT — Openings That Grab, Endings That Won't Let Go
+
+The chapter is the unit of "just one more." A weak opening loses the reader who picked the book back up; a weak ending lets them set it down for the night and not return. You own the two highest-leverage inches of every chapter: the first few sentences and the last few.
+
+You evaluate the **hook** (opening) and the **pull** (ending). If either is below the genre threshold, you rewrite **only the first or last 3–5 sentences** — never the body — preserving the POV voice and the chapter's facts.
+
+## BEFORE YOU TOUCH ANYTHING
+
+Read:
+1. The chapter file (`chapter-[N].md`).
+2. The previous chapter's ending and this chapter's neighbors in `outline.md` — so the pull sets up what actually comes next.
+3. `voice-dna.md` — the global narrative voice and the POV character's voice card.
+4. `research/bestseller-dna.md` — genre hook conventions and pacing.
+5. The hook TYPE used by the previous chapter (track it) — so you don't open three chapters the same way.
+
+## SCORING (1–10 each)
+
+Score the **hook** and the **pull** independently and write the scores in your report.
+
+**Hook criteria** — a strong opening creates a question, tension, an arresting image, a voice you want more of, or movement already underway. It earns the next paragraph.
+Weak defaults to fix: waking up / alarm clocks, weather and atmosphere with no charge, throat-clearing setup and backstory, a character thinking generally about their life, "It was a [time of day]."
+
+**Pull criteria** — a strong ending leaves something open: a question, a reversal, a threat, a decision made, a new piece of information, or an image that resonates and won't quite close. It makes stopping feel like leaving something undone.
+Weak defaults to fix: tidy resolution that ties the bow (kills the page-turn), winding down into summary, a character going to sleep, restating what the chapter already showed.
+
+## THRESHOLDS (genre-adjusted)
+
+Rewrite when a score falls below the floor for the genre (from `bestseller-dna.md`):
+- **Thriller / commercial / YA / romance** — hook and pull floor **7**. These genres live and die on momentum.
+- **Literary / upmarket** — floor **6**. Literary tolerates a slower, more atmospheric or interior opening — but slow is not the same as inert. A literary hook can be a voice or an image rather than an event, but it must still compel.
+- **Memoir / narrative NF** — floor **6.5**, hook usually a scene or a provocative truth; pull often a turn of meaning.
+- **Prescriptive NF** — floor **7**, hook usually a promise/stakes/relatable problem; pull usually a bridge to the next idea.
+
+If a score is at or above the floor, leave it. Do not rewrite a working hook to chase a 10 — note it and move on.
+
+## HOOK TYPES (vary across chapters — don't repeat the previous chapter's type)
+
+In medias res action · a question or mystery · a striking declarative/statement · a concrete strange detail · a voice-forward line · a reversal of expectation · a sensory image · a line of charged dialogue · a time/place jolt.
+
+## PULL / ENDING TYPES
+
+Cliffhanger (interrupted action) · a reveal · a new question · an emotional reversal · a decision taken · a status-quo break · an image that resonates (especially literary/memoir).
+
+## SURGICAL CONSTRAINT
+
+- Change **only** the first 3–5 sentences (hook) and/or the last 3–5 sentences (pull). Never the body.
+- Preserve the POV character's voice and the global narrative voice (`voice-dna.md`).
+- Introduce no new facts that violate `ENTITY_STATE.yaml`. A new opening image must be consistent with where/when the scene actually is and what the character knows.
+- Keep the chapter's entry and exit points the same scene — you're re-angling the camera, not relocating it.
+
+## SPECIAL CASES
+
+- **Chapter 1** — The opening is the book's `OPENING STRATEGY` chosen in `foundation.md`. Respect that strategy; refine its execution, do not override the architect's deliberate choice. If you believe it underperforms, refine within the chosen strategy and flag it in the report.
+- **Final chapter** — The ending carries the book's `EMOTIONAL RESIDUE` (see `foundation.md`). Do NOT convert it into a suspense cliffhanger. Here the "pull" is resonance and after-image, not a question — make the last sentences land and linger.
+- **Deliberate quiet beats** — Some chapters are written to breathe after an intense one. Don't jam a false cliffhanger onto a chapter whose job is the exhale; strengthen the resonance instead.
+
+## OUTPUT
+
+1. Edit the chapter **in place** if any rewrite was warranted.
+2. Write a short report to `evaluations/hook-chapter-[N].md`:
+   ```markdown
+   # Hook Craft — Chapter [N]
+
+   ## Scores
+   - Hook: [before] → [after]  (type: [hook type], prev chapter used: [type])
+   - Pull: [before] → [after]  (type: [pull type])
+
+   ## Hook
+   - Before: "[first sentences]"
+   - After:  "[first sentences]"  — or "unchanged (≥ floor)"
+   - Why: [what it now does]
+
+   ## Pull
+   - Before: "[last sentences]"
+   - After:  "[last sentences]"  — or "unchanged (≥ floor)"
+   - Why: [what it now does]
+   ```
+
+## RULES
+
+1. **Only the edges.** First 3–5 and last 3–5 sentences. The body is not yours.
+2. **Score honestly, rewrite only below floor.** Don't churn working openings; don't pass a flat one.
+3. **Vary the type.** Never open consecutive chapters the same way; track the previous chapter's hook type.
+4. **Respect the architect on Chapter 1 and the residue on the final chapter.**
+5. **Preserve voice and facts.** POV voice intact; no `ENTITY_STATE` contradictions.
+6. **A pull is an opening, not a closing.** Except the final chapter, never tie the bow — leave the reader needing the next page.

--- a/assets/social/card-pipeline.svg
+++ b/assets/social/card-pipeline.svg
@@ -79,6 +79,6 @@
   <!-- Footer -->
   <line x1="380" y1="950" x2="700" y2="950" stroke="#D4A574" stroke-opacity="0.4" stroke-width="1"/>
   <text x="540" y="990" font-family="Inter, Helvetica, sans-serif" font-size="18" letter-spacing="6" text-anchor="middle" fill="#D4A574">
-    BOOK GENESIS · github.com/felipelobomotta-blip/best-seller-studio
+    BOOK GENESIS · github.com/felipelobomotta-blip/book-genesis-v4
   </text>
 </svg>

--- a/assets/social/videos/generate_tutorial_2026-05-25.py
+++ b/assets/social/videos/generate_tutorial_2026-05-25.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Book Genesis — "How to use it" step-by-step tutorial (terminal screencast style)
-# Real commands + real 8-phase pipeline from the repo (best-seller-studio).
+# Real commands + real 8-phase pipeline from the repo (book-genesis-v4).
 import sys, math, subprocess
 from PIL import Image, ImageDraw, ImageFont
 
@@ -149,7 +149,7 @@ T={
   'i_top':"HOW TO USE",'i_big':"Book Genesis",
   'i_sub':"From an idea to a scored, market-ready book — step by step.",
   's1_lab':"STEP 1 · INSTALL",'s1_cap':"Clone the repo and install the skills.",
-  's1':[('cmd','git clone .../best-seller-studio'),('cmd','cd best-seller-studio'),
+  's1':[('cmd','git clone .../book-genesis-v4'),('cmd','cd book-genesis-v4'),
         ('cmd','./install.ps1'),('ok','9 book-studio skills installed')],
   's2_lab':"STEP 2 · POINT ANY AGENT",'s2_cap':"Works in any agent that reads files.",
   's2':[('comment','# Claude Code / Codex / Antigravity / Kimi'),
@@ -185,14 +185,14 @@ T={
         ('out','done. a book package you can audit.')],
   'cta_pre':"BOOK GENESIS",
   'cta1':"Open source. Runs on any agent\nthat reads files.",
-  'url':"github.com/felipelobomotta-blip/best-seller-studio",
+  'url':"github.com/felipelobomotta-blip/book-genesis-v4",
   'cta_sub':"MIT - Claude Code - Codex - Kimi - Antigravity",
  },
  'pt':{
   'i_top':"COMO USAR",'i_big':"Book Genesis",
   'i_sub':"De uma ideia a um livro pontuado e pronto pro mercado — passo a passo.",
   's1_lab':"PASSO 1 · INSTALAR",'s1_cap':"Clone o repo e instale as skills.",
-  's1':[('cmd','git clone .../best-seller-studio'),('cmd','cd best-seller-studio'),
+  's1':[('cmd','git clone .../book-genesis-v4'),('cmd','cd book-genesis-v4'),
         ('cmd','./install.ps1'),('ok','9 skills de estudio instaladas')],
   's2_lab':"PASSO 2 · APONTE QUALQUER AGENTE",'s2_cap':"Funciona em qualquer agente que le arquivo.",
   's2':[('comment','# Claude Code / Codex / Antigravity / Kimi'),
@@ -228,7 +228,7 @@ T={
         ('out','pronto. um pacote de livro auditavel.')],
   'cta_pre':"BOOK GENESIS",
   'cta1':"Open source. Roda em qualquer agente\nque le arquivo.",
-  'url':"github.com/felipelobomotta-blip/best-seller-studio",
+  'url':"github.com/felipelobomotta-blip/book-genesis-v4",
   'cta_sub':"MIT - Claude Code - Codex - Kimi - Antigravity",
  },
 }

--- a/assets/social/videos/generate_video_2026-05-25_19x.py
+++ b/assets/social/videos/generate_video_2026-05-25_19x.py
@@ -101,7 +101,7 @@ T = {
   'lesson3':"wins from decomposition.",
   'cta_pre':"BOOK GENESIS",
   'cta1':"Open source. Runs on any agent\nthat reads files.",
-  'url':"github.com/felipelobomotta-blip/best-seller-studio",
+  'url':"github.com/felipelobomotta-blip/book-genesis-v4",
   'cta_sub':"MIT · Claude Code · Codex · Kimi · Antigravity",
  },
  'pt':{
@@ -125,7 +125,7 @@ T = {
   'lesson3':"ganha com decomposição.",
   'cta_pre':"BOOK GENESIS",
   'cta1':"Open source. Roda em qualquer agente\nque lê arquivo.",
-  'url':"github.com/felipelobomotta-blip/best-seller-studio",
+  'url':"github.com/felipelobomotta-blip/book-genesis-v4",
   'cta_sub':"MIT · Claude Code · Codex · Kimi · Antigravity",
  }
 }

--- a/docs/distribution-kit.md
+++ b/docs/distribution-kit.md
@@ -2,7 +2,7 @@
 
 Public launch kit for the English-first GitHub repo.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Primary positioning:
 
@@ -112,7 +112,7 @@ The repo ships the system:
 
 ```text
 Repo:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 
 MIT licensed. Built for writers and builders who want a production loop, not a pile of drafts.
 ```
@@ -138,7 +138,7 @@ research, book architecture, developmental editing, literary-agent panel, MiroFi
 It works with repo-aware agents like Claude Code, Codex, Kimi, and Antigravity because it is just files: markdown instructions, scoring contracts, manifests, and durable project state.
 
 Repo:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 ```
 
 ## Hacker News

--- a/docs/i18n-guide.md
+++ b/docs/i18n-guide.md
@@ -49,7 +49,7 @@ Two levels:
 Translate high-level docs. Low friction. Great first PR.
 
 - `README.md` → `README.<lang>.md`
-- `docs/agents-<lang>.md` — one-line descriptions of the 8 agents
+- `docs/agents-<lang>.md` — one-line descriptions of the 11 agents
 - `SHOWCASE.md` → `SHOWCASE.<lang>.md` if worthwhile
 
 ### Level 2 — Agent prompts
@@ -70,7 +70,7 @@ The pipeline is currently left-to-right only. Arabic, Hebrew, Persian would need
 2. RTL-aware demo assets (currently LTR-only)
 3. Native reviewer for the evaluator's phonetic/rhythm rules (very different from LTR languages)
 
-We welcome a PR that opens this direction. Talk to us in [Discussions](https://github.com/felipelobomotta-blip/best-seller-studio/discussions) first — the design work is bigger than the PR.
+We welcome a PR that opens this direction. Talk to us in [Discussions](https://github.com/felipelobomotta-blip/book-genesis-v4/discussions) first — the design work is bigger than the PR.
 
 ## Encoding
 

--- a/docs/international-social-campaign.md
+++ b/docs/international-social-campaign.md
@@ -5,7 +5,7 @@ Goal: position Book Genesis as an open-source AI book studio for global builders
 Repo:
 
 ```text
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 ```
 
 Core positioning:
@@ -118,7 +118,7 @@ Post 6:
 
 ```text
 Repo:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 
 MIT licensed. Feedback welcome from writers, agent builders, publishing-tech teams, and long-form workflow nerds.
 ```

--- a/docs/reddit-launch-kit.md
+++ b/docs/reddit-launch-kit.md
@@ -66,7 +66,7 @@ The repo now includes:
 - portability notes for Claude Code, Codex, Antigravity, Kimi, and generic agents
 
 Repo:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 
 The most interesting files:
 
@@ -123,7 +123,7 @@ So I rebuilt it as a smaller universal core:
 
 ```text
 Repo:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 
 The proof layer:
 10+ book projects, covers/cover concepts, case studies, scoring artifacts, and the portable skill.
@@ -145,7 +145,7 @@ The surprising part was that the larger version of the system - 17 phases, 19 sk
 The current version is smaller and agent-agnostic: durable project files, one active phase prompt at a time, adversarial audit before scoring, and an editorial package after the manuscript survives critique. It can run in Claude Code, Codex, Antigravity, Kimi, or any agent that can read and write files.
 
 Repo:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Useful files:
 - docs/book-gallery.md

--- a/docs/reddit-posts-bg-launch.md
+++ b/docs/reddit-posts-bg-launch.md
@@ -2,7 +2,7 @@
 
 Four English launch posts with different angles. Stagger them. Do not cross-post identical copy.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 ## 1. r/ClaudeAI
 
@@ -29,7 +29,7 @@ Everything persists to files: `PROJECT_STATE.yaml`, `ASSUMPTIONS.md`, `manuscrip
 
 The goal is not "AI writes a book in one shot." The goal is a repeatable production loop with evidence, gates, and revision pressure.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Curious how others are structuring multi-skill Claude Code workflows.
 
@@ -57,7 +57,7 @@ Book Genesis is the open-source version. It is markdown-first and agent-agnostic
 
 The repo includes public case studies, cover concepts, scoring docs, skills, runner scripts, and launch materials. Manuscripts stay private.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Feedback welcome, especially from builders making long-form agent workflows.
 
@@ -84,7 +84,7 @@ Key design choice: adversarial audit happens before the quantitative score. The 
 
 The current repo also includes a 9-skill book studio: researcher, editor, agent panel, reader swarm, copyeditor, humanizer, and editorial packager.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Interested in whether this pattern generalizes beyond fiction: courses, reports, research briefs, grants, game narratives, etc.
 
@@ -106,7 +106,7 @@ Book Genesis is the open-source version of that workflow. It runs as a file-back
 
 It also includes a simulated agent/editor panel and reader-swarm diagnostics, but those are decision aids, not replacements for human readers.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 
 I would especially appreciate feedback from writers on what the audit phase should catch before a score is allowed.
 

--- a/docs/viral-launch-tasks.md
+++ b/docs/viral-launch-tasks.md
@@ -235,7 +235,7 @@ The counterintuitive part: the larger 17-phase / 19-skill version made the books
 
 The current version is smaller, agent-agnostic, and works with Claude Code, Codex, Antigravity, Kimi, or any agent that can read/write files.
 
-Repo: https://github.com/felipelobomotta-blip/best-seller-studio
+Repo: https://github.com/felipelobomotta-blip/book-genesis-v4
 Proof layer: docs/book-gallery.md
 ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -31,20 +31,22 @@ foreach ($dir in @($TargetSkills, $TargetKnowledge, $TargetAgents)) {
     }
 }
 
+# Skills live at skills\<name>\ AND in grouping folders like skills\optional\<name>\.
+# Discover SKILL.md at any depth so nested groups are not silently skipped.
+# skills\deprecated\ is intentionally excluded - those are superseded by agents\.
 $count = 0
-Get-ChildItem -Path $SkillsDir -Directory | ForEach-Object {
-    $skillName = $_.Name
-    $skillFile = Join-Path $_.FullName "SKILL.md"
-    if (Test-Path $skillFile) {
-        $destDir = Join-Path $TargetSkills $skillName
-        if (Test-Path $destDir) {
-            Remove-Item -LiteralPath $destDir -Recurse -Force
-        }
-        New-Item -ItemType Directory -Path $destDir -Force | Out-Null
-        Copy-Item -Path (Join-Path $_.FullName "*") -Destination $destDir -Recurse -Force
-        Write-Host "  + $skillName" -ForegroundColor Green
-        $count++
+Get-ChildItem -Path $SkillsDir -Filter "SKILL.md" -File -Recurse | ForEach-Object {
+    $skillDir = $_.Directory
+    if ($skillDir.FullName -match '[\\/]deprecated[\\/]') { return }
+    $skillName = $skillDir.Name
+    $destDir = Join-Path $TargetSkills $skillName
+    if (Test-Path $destDir) {
+        Remove-Item -LiteralPath $destDir -Recurse -Force
     }
+    New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+    Copy-Item -Path (Join-Path $skillDir.FullName "*") -Destination $destDir -Recurse -Force
+    Write-Host "  + $skillName" -ForegroundColor Green
+    $count++
 }
 
 $kbCount = 0
@@ -64,6 +66,25 @@ if (Test-Path $AgentsDir) {
         $agentCount++
     }
 }
+
+# Verify every subagent_type the orchestrator dispatches is actually installed.
+# A missing one stalls the pipeline mid-run, so fail loudly here instead.
+$PipelineAgents = @(
+    "book-researcher", "book-architect", "entity-tracker", "continuity-guardian",
+    "book-writer", "dialogue-polish", "hook-craft", "book-disruptor",
+    "book-evaluator", "book-editor", "book-packager"
+)
+$missing = $PipelineAgents | Where-Object { -not (Test-Path (Join-Path $TargetAgents "$_.md")) }
+
+Write-Host ""
+if ($missing) {
+    Write-Host "Pipeline incomplete. The orchestrator dispatches agents that are not installed:" -ForegroundColor Red
+    $missing | ForEach-Object { Write-Host "  - $_" -ForegroundColor Red }
+    Write-Host ""
+    Write-Host "The book-orchestrator will stall when it reaches one of these."
+    exit 1
+}
+Write-Host "Pipeline verified. All 11 orchestrator agents resolve." -ForegroundColor Green
 
 Write-Host ""
 Write-Host "Done. $count skills + $agentCount agents + $kbCount knowledge files installed" -ForegroundColor Green

--- a/install.sh
+++ b/install.sh
@@ -32,17 +32,22 @@ fi
 
 mkdir -p "$TARGET_SKILLS" "$TARGET_KNOWLEDGE" "$TARGET_AGENTS"
 
+# Skills live at skills/<name>/ AND in grouping folders like skills/optional/<name>/.
+# Discover SKILL.md at any depth so nested groups are not silently skipped.
+# skills/deprecated/ is intentionally excluded — those are superseded by agents/.
 count=0
-for skill_dir in "$SKILLS_DIR"/*/; do
+while IFS= read -r skill_file; do
+  skill_dir=$(dirname "$skill_file")
   skill_name=$(basename "$skill_dir")
-  if [ -f "$skill_dir/SKILL.md" ]; then
-    rm -rf "$TARGET_SKILLS/$skill_name"
-    mkdir -p "$TARGET_SKILLS/$skill_name"
-    cp -R "$skill_dir". "$TARGET_SKILLS/$skill_name/"
-    echo -e "  ${GREEN}+${NC} $skill_name"
-    count=$((count + 1))
-  fi
-done
+  case "$skill_dir" in
+    */deprecated/*) continue ;;
+  esac
+  rm -rf "$TARGET_SKILLS/$skill_name"
+  mkdir -p "$TARGET_SKILLS/$skill_name"
+  cp -R "$skill_dir/." "$TARGET_SKILLS/$skill_name/"
+  echo -e "  ${GREEN}+${NC} $skill_name"
+  count=$((count + 1))
+done < <(find "$SKILLS_DIR" -maxdepth 3 -name SKILL.md -type f | sort)
 
 kb_count=0
 if [ -d "$KNOWLEDGE_DIR" ]; then
@@ -65,6 +70,28 @@ if [ -d "$AGENTS_DIR" ]; then
     fi
   done
 fi
+
+# Verify every subagent_type the orchestrator dispatches is actually installed.
+# A missing one stalls the pipeline mid-run, so fail loudly here instead.
+PIPELINE_AGENTS="book-researcher book-architect entity-tracker continuity-guardian book-writer dialogue-polish hook-craft book-disruptor book-evaluator book-editor book-packager"
+missing=""
+for agent in $PIPELINE_AGENTS; do
+  if [ ! -f "$TARGET_AGENTS/$agent.md" ]; then
+    missing="$missing $agent"
+  fi
+done
+
+echo ""
+if [ -n "$missing" ]; then
+  echo -e "${RED}Pipeline incomplete.${NC} The orchestrator dispatches agents that are not installed:"
+  for agent in $missing; do
+    echo -e "  ${RED}-${NC} $agent"
+  done
+  echo ""
+  echo "The book-orchestrator will stall when it reaches one of these."
+  exit 1
+fi
+echo -e "${GREEN}Pipeline verified.${NC} All 11 orchestrator agents resolve."
 
 echo ""
 echo -e "${GREEN}Done.${NC} $count skills + $agent_count agents + $kb_count knowledge files installed"

--- a/scripts/distribution/hackernews-post.mjs
+++ b/scripts/distribution/hackernews-post.mjs
@@ -11,7 +11,7 @@ The current version is smaller and agent-agnostic: durable project files, one ac
 It runs in Claude Code, Codex, Antigravity, Kimi, or any agent that can read and write files. No proprietary format, no lock-in.
 
 Repo:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Useful files:
 - docs/book-gallery.md (10-book proof gallery)
@@ -76,7 +76,7 @@ await titleInput.fill(postTitle);
 
 // Fill URL
 const urlInput = page.locator('input[name="url"]');
-await urlInput.fill("https://github.com/felipelobomotta-blip/best-seller-studio");
+await urlInput.fill("https://github.com/felipelobomotta-blip/book-genesis-v4");
 
 // HN text area (may not be visible if URL is filled)
 const textInput = page.locator('textarea[name="text"]');

--- a/scripts/distribution/linkedin-post.mjs
+++ b/scripts/distribution/linkedin-post.mjs
@@ -35,7 +35,7 @@ If you're building with AI agents — whether books, code, or operations — the
 Repo and proof layer in the comments.`;
 
 const commentBody = `Link to the repository with the pipeline, cover gallery, case studies, and portable skill:
-https://github.com/felipelobomotta-blip/best-seller-studio
+https://github.com/felipelobomotta-blip/book-genesis-v4
 
 Key docs:
 - docs/book-gallery.md (10+ project proof)

--- a/scripts/distribution/reddit-launch.mjs
+++ b/scripts/distribution/reddit-launch.mjs
@@ -1,6 +1,6 @@
 import { chromium } from "playwright";
 
-const repoUrl = "https://github.com/felipelobomotta-blip/best-seller-studio";
+const repoUrl = "https://github.com/felipelobomotta-blip/book-genesis-v4";
 const subreddit = "ClaudeAI";
 const postTitle = `I stress-tested AI agents on 10+ book projects in under 30 days. The 19-skill version was worse.`;
 

--- a/scripts/distribution/twitter-thread.mjs
+++ b/scripts/distribution/twitter-thread.mjs
@@ -7,7 +7,7 @@ const tweets = [
   `So I rebuilt it as a smaller, file-backed core:\n\n• One active phase at a time\n• PROJECT_STATE.yaml + ASSUMPTIONS.md\n• Draft first, judge after\n• Adversarial audit before final score\n• Editorial package only after the manuscript survives critique`,
   `The result:\n\n10+ book projects with covers, case studies, scoring artifacts, and outlines.\n\nThe manuscripts are private.\n\nThe pipeline, proof layer, and portable skill are open-source.`,
   `It runs as a file-backed workflow in:\n\n• Claude Code\n• Codex\n• Antigravity\n• Kimi\n• Any agent that can read/write project files\n\nNo lock-in. No proprietary format. Just durable state files and phase prompts.`,
-  `If you're building long-form agent workflows, I'm curious:\n\nHave you seen the same tradeoff — more live constraints improving consistency but hurting voice?\n\nRepo + proof gallery:\nhttps://github.com/felipelobomotta-blip/best-seller-studio`,
+  `If you're building long-form agent workflows, I'm curious:\n\nHave you seen the same tradeoff — more live constraints improving consistency but hurting voice?\n\nRepo + proof gallery:\nhttps://github.com/felipelobomotta-blip/book-genesis-v4`,
   `The lesson that took me 10 books to learn:\n\nA pipeline beats a prompt.\n\nBut a smaller pipeline beats a bigger one.`
 ];
 

--- a/video-demo/package.json
+++ b/video-demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "best-seller-studio-demo",
+  "name": "book-genesis-v4-demo",
   "version": "1.0.0",
   "description": "Demo video for Best Seller Studio — AI book pipeline",
   "scripts": {

--- a/video-demo/src/Scene2Idea.tsx
+++ b/video-demo/src/Scene2Idea.tsx
@@ -134,7 +134,7 @@ export const Scene2Idea: React.FC = () => {
             transition: 'opacity 0.3s',
           }}
         >
-          best-seller-studio --run pipeline
+          book-genesis-v4 --run pipeline
         </div>
       </div>
     </div>

--- a/video-demo/src/Scene6CTA.tsx
+++ b/video-demo/src/Scene6CTA.tsx
@@ -114,7 +114,7 @@ export const Scene6CTA: React.FC = () => {
                 letterSpacing: '0.02em',
               }}
             >
-              github.com/felipelobomotta-blip/best-seller-studio
+              github.com/felipelobomotta-blip/book-genesis-v4
             </span>
           </div>
         </div>

--- a/web/landing.html
+++ b/web/landing.html
@@ -293,7 +293,7 @@
     <p class="lede" data-lang-pt>Um pipeline de produção de livros com IA, agnóstico de agente. Leve uma ideia de uma linha por pesquisa, escrita, auditoria adversarial, pontuação e empacotamento editorial — no Claude Code, Codex, Antigravity, Kimi ou qualquer agente que enxergue arquivos.</p>
 
     <div class="ctas">
-      <a class="btn btn-primary" href="https://github.com/felipelobomotta-blip/best-seller-studio" target="_blank" rel="noopener">
+      <a class="btn btn-primary" href="https://github.com/felipelobomotta-blip/book-genesis-v4" target="_blank" rel="noopener">
         <span data-lang-en>Open on GitHub →</span>
         <span data-lang-pt>Abrir no GitHub →</span>
       </a>
@@ -571,7 +571,7 @@
     <p class="quote" data-lang-en>Built for writers who want to <em>run the loop,</em><br>not babysit it.</p>
     <p class="quote" data-lang-pt>Feito pra escritores que querem <em>rodar o loop,</em><br>não vigiar ele.</p>
     <div class="ctas" style="justify-content: center;">
-      <a class="btn btn-primary" href="https://github.com/felipelobomotta-blip/best-seller-studio" target="_blank" rel="noopener">
+      <a class="btn btn-primary" href="https://github.com/felipelobomotta-blip/book-genesis-v4" target="_blank" rel="noopener">
         <span data-lang-en>Star on GitHub</span>
         <span data-lang-pt>Estrelar no GitHub</span>
       </a>
@@ -583,7 +583,7 @@
   <div class="container">
     <span data-lang-en>MIT licensed · </span>
     <span data-lang-pt>Licença MIT · </span>
-    <a href="https://github.com/felipelobomotta-blip/best-seller-studio" target="_blank" rel="noopener">github.com/felipelobomotta-blip/best-seller-studio</a>
+    <a href="https://github.com/felipelobomotta-blip/book-genesis-v4" target="_blank" rel="noopener">github.com/felipelobomotta-blip/book-genesis-v4</a>
   </div>
 </footer>
 


### PR DESCRIPTION
Fixes #16.

## The bug

`book-orchestrator` dispatches 11 `subagent_type` values, but only 8 shipped in `agents/`. The missing four — `entity-tracker`, `continuity-guardian`, `dialogue-polish`, `hook-craft` — existed only as *skills* under `skills/optional/` and `skills/deprecated/`.

Two things made this unrecoverable for users:

1. A skill cannot resolve as a `subagent_type`. Even installed, they wouldn't have worked.
2. `install.sh` never reached them anyway. Its loop tested `-f "$skill_dir/SKILL.md"` against `skills/*/`, and `optional/` and `deprecated/` are grouping folders with no `SKILL.md` at their root — so both were silently skipped.

The README's `cp agents/*.md ~/.claude/agents/` delivered 8. `install.sh` also delivered 8. Every clean install stalled at **Phase 2.7**, immediately after Checkpoint 1 — exactly as reported.

Two of the four (`dialogue-polish`, `hook-craft`) are Steps B and C of *every chapter*, so the pipeline's hot path depended on a `deprecated/` folder.

## Changes

**Add the four agents to `agents/`.** Their dispatch contracts match what `book-orchestrator` already passes — `BUILD`/`UPDATE` for `entity-tracker`, `OUTLINE AUDIT`/`MANUSCRIPT AUDIT` for `continuity-guardian`, and the documented read/write paths for all four.

**Fix installer discovery.** Both installers now find `SKILL.md` at any depth, so nested groups are no longer skipped. `skills/deprecated/` is excluded deliberately, now that its two hot-path skills are proper agents.

**Add a post-install guard.** Both installers verify all 11 dispatched agents resolve and exit non-zero if any is missing. A missing agent now fails at install time instead of mid-manuscript.

**Point the README at the installer.** Step 2 called `cp agents/*.md`, which installs no skills and no knowledge base — the pipeline also reads `~/.claude/knowledge/`.

**Correct the repository name.** 32 links said `best-seller-studio`, including the `git clone` in the quick start and the URLs the distribution scripts post to Reddit, HN, LinkedIn and X.

**Update the agent count** from 8 to 11 in the badge, intro, and agents table.

## Verification

```
12 tests passing
install.sh exit 0 → "Pipeline verified. All 11 orchestrator agents resolve."
22 skills (was 19) + 12 agents (was 8) + 5 knowledge files
removing any one agent → exit 1 (guard confirmed)
0 stale repo references
```

Installers tested against a sandboxed `HOME`.

## Known remaining

The `.mp4` assets still show the old URL burned into their frames. The generator scripts are fixed; the videos need a re-render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the book-generation pipeline to 11 specialized agents, including continuity auditing, dialogue polishing, entity tracking, and hook crafting.
  * Installers now discover nested skills and verify that all required pipeline agents are available.
* **Documentation**
  * Updated setup guidance, agent descriptions, translation guidance, security reporting, and release checklists.
* **Updates**
  * Refreshed website, video demos, tutorials, and promotional materials with the current repository links and commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->