### PR TITLE
Polish demo captions and add the first launch packet

### DIFF
--- a/marketing/README.md
+++ b/marketing/README.md
@@ -8,6 +8,7 @@ This is the complete English launch kit. Narrated videos, artwork, and carousel 
 | --- | --- |
 | [`../docs/video-walkthrough.md`](../docs/video-walkthrough.md) | Finished 60-second walkthrough, 33-second vertical cut, English subtitles, and editable source. |
 | [`video-social-copy.md`](video-social-copy.md) | Video titles, descriptions, and copy for YouTube, Shorts, Reels, TikTok, X, and LinkedIn. |
+| [`launch/README.md`](launch/README.md) | First-launch packet: final YouTube, LinkedIn, and X copy, plus a blank results sheet. |
 | [`copy/en.md`](copy/en.md) | English copy ready to adapt and publish. |
 | [`calendar-14-days.csv`](calendar-14-days.csv) | Measurable D0–D13 launch sequence without invented dates or times. |
 | [`carousel-script.md`](carousel-script.md) | Six-slide English carousel copy. |

--- a/marketing/launch/README.md
+++ b/marketing/launch/README.md
@@ -1,0 +1,102 @@
+# Book Genesis 5 — first-launch packet
+
+**Status: prepared, not posted.** No account, publication date, view count, user count, or feedback outcome is implied by this packet.
+
+Start with one channel and collect feedback on installation and the writing workflow before expanding the launch. The recommended sequence is private YouTube upload first, then a founder LinkedIn post, then one concise X post. It gives the video a stable destination, explains the product in a professional context, and leaves one short linkable version for real-time discussion.
+
+## Recommended order
+
+1. **YouTube: upload the main walkthrough as a private draft.** Check the title, description, thumbnail, English captions, and the scripted-fixture disclosure before choosing a visibility setting.
+2. **LinkedIn: publish the founder post after the video is public or unlisted.** Use the repository link as the primary call to action. Add the video link only after it exists.
+3. **X: publish the short post after LinkedIn.** Attach the vertical video if the chosen account supports it; otherwise use the repository URL exactly as written below.
+4. **Record outcomes only after each action is actually published.** Use `results.csv`; leave unknown values blank.
+
+This order is a recommendation, not an automatic schedule. Channel/account selection and any external publishing remain pending.
+
+## Verified assets
+
+| Use | Public URL |
+| --- | --- |
+| Main walkthrough — 59.9s, landscape MP4 | [Download](https://github.com/felipelobomotta-blip/book-genesis-v4/releases/download/v5.0.0-beta.1/book-genesis-5-walkthrough-en.mp4) |
+| Vertical cut — 32.8s, vertical MP4 | [Download](https://github.com/felipelobomotta-blip/book-genesis-v4/releases/download/v5.0.0-beta.1/book-genesis-5-vertical-en.mp4) |
+| Video kit — MP4s, posters, English SRT/WebVTT, posting copy | [Download ZIP](https://github.com/felipelobomotta-blip/book-genesis-v4/releases/download/v5.0.0-beta.1/book-genesis-5-video-kit-en.zip) |
+| Release page | [Open release](https://github.com/felipelobomotta-blip/book-genesis-v4/releases/tag/v5.0.0-beta.1) |
+| Repository | [Open repository](https://github.com/felipelobomotta-blip/book-genesis-v4) |
+| Video provenance and setup guide | [Open guide](https://github.com/felipelobomotta-blip/book-genesis-v4/blob/master/docs/video-walkthrough.md) |
+
+## Final copy: YouTube private draft
+
+**Recommended upload asset:** the landscape walkthrough MP4.
+
+**Title**
+
+```text
+How Book Genesis 5 turns one idea into a documented writing workflow
+```
+
+**Description**
+
+```text
+What happens after you have the premise but before you have a manuscript?
+
+Book Genesis 5 — Imagination Edition is an open-source CLI for developing an idea through a guided brief, outline, chapter workflow, blind model-reader feedback, a manuscript audit, a local reader, and Markdown or EPUB export.
+
+Install Python 3.10+, connect a supported model route, and start with one sentence. You can leave notes at the brief, outline, and chapter-one checkpoints, pause safely, and resume later. The local reader keeps revision history visible and lets you compare versions. Export writes accepted canonical chapters; incomplete projects are labeled as partial.
+
+This 59.9-second walkthrough uses edited-time sequences and a clearly labeled scripted English interface fixture. It is not live provider generation, human-reader validation, or a claim of publication readiness.
+
+Explore the controlled beta:
+https://github.com/felipelobomotta-blip/book-genesis-v4
+
+Release and downloads:
+https://github.com/felipelobomotta-blip/book-genesis-v4/releases/tag/v5.0.0-beta.1
+
+#BookGenesis #CreativeWriting #WritingTools #OpenSource #IndieAuthors
+```
+
+**Private-draft checklist**
+
+- Visibility: Private until the founder selects the account, timing, and final release setting.
+- Language: English.
+- Captions: use the matching English subtitle file in the video kit.
+- Thumbnail: use `walkthrough-poster.jpg` from the video kit.
+- Keep the scripted-fixture and edited-time disclosure in the description.
+
+## Final copy: LinkedIn
+
+**Recommended attachment:** the landscape walkthrough MP4 or its public YouTube link after it is available.
+
+```text
+I built Book Genesis for the stories we keep saying we will write someday.
+
+You bring the premise. The workflow helps you develop the brief, outline, and chapter drafts. You make the decisions at the author checkpoints.
+
+You can leave notes, pause and resume, compare versions in a local reader, and export accepted chapters as Markdown or EPUB.
+
+Book Genesis 5 is open source and in beta. The video uses a labeled scripted story to demonstrate the actual interface.
+
+Creativity comes first. Your story. Your choices.
+
+What is the story you have been meaning to start?
+https://github.com/felipelobomotta-blip/book-genesis-v4
+
+#CreativeWriting #OpenSource #BookGenesis
+```
+
+## Final copy: X
+
+**Recommended attachment:** the vertical MP4. This copy includes the repository URL and remains within the standard X post limit before adding an account mention.
+
+```text
+An idea deserves a first chapter. Book Genesis 5 is an open-source writing workflow with author checkpoints, model feedback, a local reader, and EPUB export. Watch the labeled sample demo. Creativity comes first.
+https://github.com/felipelobomotta-blip/book-genesis-v4
+```
+
+## Provenance and claims boundary
+
+The videos are edited-time demonstrations. Their terminal and reader sequences are recorded from a **clearly labeled scripted English interface fixture**. They are not live provider generation, evidence of literary quality, human-reader validation, publication readiness, or bestseller results. The narration is synthetic English narration. Public copy should retain these limits whenever the demonstration is shared.
+
+## What to measure after publication
+
+Use [results.csv](results.csv) to capture only observed values. “Repository visits” should use an available GitHub traffic figure only when the measurement window and source are recorded. “Setup attempts” and “feedback” mean concrete, attributable signals such as a reproducible issue, Discussion comment, installation report, or direct reply; do not infer them from impressions.
+

--- a/marketing/launch/results.csv
+++ b/marketing/launch/results.csv
@@ -1,0 +1,2 @@
+measurement_window_start,measurement_window_end,channel_or_source,asset_or_post,publication_status,views,repo_visits_if_available,concrete_setup_attempts,concrete_feedback,source_or_link,notes
+,,,,prepared_not_posted,,,,,,

--- a/video-demo/imagination/README.md
+++ b/video-demo/imagination/README.md
@@ -47,6 +47,8 @@ Export includes accepted canonical chapters. A working project can be exported b
 
 Install the Python repository first, then run `python scripts/capture_cli.py` to regenerate the Rich HTML and the reader fixture. It uses a new temporary project and fake responses, and does not call a real provider. The script leaves its temporary fixture directory available for inspection. Take new PNG screenshots of the resulting HTML and record any new reader interactions before replacing the matching media files.
 
+Regenerated command and export paths use portable forward slashes in the displayed transcript; the runner receives native paths. The published video screenshots retain the path formatting of the original recording session.
+
 Optional Windows narration regeneration: run `scripts/generate_voice.ps1` in a PowerShell session with the Microsoft Zira Desktop voice and FFprobe installed. It rewrites the WAVs and timing JSON. If wording or durations change, update the checkpoint scene timings and subtitles before rendering again. You can also record your own English narration and update the paths and durations directly.
 
 Final video binaries are attached to the GitHub release rather than stored in Git. Rebuilds on another OS or with different fonts may differ visually.

--- a/video-demo/imagination/public/captions/book-genesis-5-long.en.srt
+++ b/video-demo/imagination/public/captions/book-genesis-5-long.en.srt
@@ -50,7 +50,7 @@ and compare versions.
 12
 00:00:42,133 --> 00:00:45,400
 Export your working manuscript
-as Markdown or E pub.
+as Markdown or EPUB.
 
 13
 00:00:45,400 --> 00:00:49,700

--- a/video-demo/imagination/public/captions/book-genesis-5-long.en.vtt
+++ b/video-demo/imagination/public/captions/book-genesis-5-long.en.vtt
@@ -40,7 +40,7 @@ and compare versions.
 
 00:00:42.133 --> 00:00:45.400
 Export your working manuscript
-as Markdown or E pub.
+as Markdown or EPUB.
 
 00:00:45.400 --> 00:00:49.700
 Incomplete projects are labeled as partial.

--- a/video-demo/imagination/public/captions/book-genesis-5-short.en.srt
+++ b/video-demo/imagination/public/captions/book-genesis-5-short.en.srt
@@ -32,7 +32,7 @@ Read locally and compare versions.
 
 9
 00:00:22,733 --> 00:00:26,233
-Export your working manuscript as E pub.
+Export your working manuscript as EPUB.
 
 10
 00:00:26,233 --> 00:00:29,000

--- a/video-demo/imagination/public/captions/book-genesis-5-short.en.vtt
+++ b/video-demo/imagination/public/captions/book-genesis-5-short.en.vtt
@@ -25,7 +25,7 @@ Leave a note, pause, and resume.
 Read locally and compare versions.
 
 00:00:22.733 --> 00:00:26.233
-Export your working manuscript as E pub.
+Export your working manuscript as EPUB.
 
 00:00:26.233 --> 00:00:29.000
 Book Genesis Five. Open source beta.

--- a/video-demo/imagination/public/capture-pages/capture-export.html
+++ b/video-demo/imagination/public/capture-pages/capture-export.html
@@ -5,6 +5,7 @@
 <style>
 .r1 {color: #58d1eb; text-decoration-color: #58d1eb; font-weight: bold}
 .r2 {font-weight: bold}
+.r3 {color: #f4005f; text-decoration-color: #f4005f}
 body {
     color: #d9d9d9;
     background-color: #0c0c0c;
@@ -12,8 +13,8 @@ body {
 </style>
 </head>
 <body style="margin:0;padding:24px">
-    <pre style="font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace"><code style="font-family:inherit"><span class="r1">$ book-genesis export books\lantern-demo --format epub</span>
-export: <span class="r2">[</span>project<span class="r2">]</span>\exports\manuscript.epub
+    <pre style="font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace"><code style="font-family:inherit"><span class="r1">$ book-genesis export books/lantern-demo --format epub</span>
+export: <span class="r2">[</span>project<span class="r2">]</span><span class="r3">/exports/</span><span class="r3">manuscript.epub</span>
 
 </code></pre>
 </body>

--- a/video-demo/imagination/public/capture-pages/capture-export.txt
+++ b/video-demo/imagination/public/capture-pages/capture-export.txt
@@ -1,1 +1,1 @@
-export: [project]\exports\manuscript.epub
+export: [project]/exports/manuscript.epub

--- a/video-demo/imagination/public/capture-pages/recording-evidence.json
+++ b/video-demo/imagination/public/capture-pages/recording-evidence.json
@@ -9,12 +9,12 @@
   "capture-export": {
     "args": [
       "export",
-      "books\\lantern-demo",
+      "books/lantern-demo",
       "--format",
       "epub"
     ],
     "exit_code": 0,
-    "output": "export: [project]\\exports\\manuscript.epub\n"
+    "output": "export: [project]/exports/manuscript.epub\n"
   },
   "guided": {
     "new_exit": 0,

--- a/video-demo/imagination/scripts/capture_cli.py
+++ b/video-demo/imagination/scripts/capture_cli.py
@@ -1,84 +1,170 @@
 """Record real runner output with deterministic, explicitly labeled fixtures."""
+
 from pathlib import Path
-import contextlib, importlib.util, io, json, os, sys, tempfile
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
 from unittest.mock import patch
 from rich.console import Console
 from rich.terminal_theme import MONOKAI
 
 SOURCE = Path(__file__).resolve().parents[3]
-OUT = Path(__file__).resolve().parents[1] / 'public'
-CAP = OUT / 'capture-pages'
+OUT = Path(__file__).resolve().parents[1] / "public"
+CAP = OUT / "capture-pages"
 CAP.mkdir(parents=True, exist_ok=True)
 sys.path.insert(0, str(SOURCE))
-from runner.app import main, session_main
-from runner.ui import RichView
-from runner.review import build_review
+# Load the repository runner after adding the checkout to the module path.
+from runner.app import main, session_main  # noqa: E402
+from runner.ui import RichView  # noqa: E402
+
 
 def write_html(name, console):
-    page=console.export_html(clear=True,theme=MONOKAI)
+    page = console.export_html(clear=True, theme=MONOKAI)
     # This only frames unmodified Rich console output for screen recording.
-    page=page.replace('<body>', '<body style="margin:0;padding:24px">').replace(str(RUN), '[capture-folder]')
-    (CAP/f'{name}.html').write_text(page,encoding='utf-8')
+    page = page.replace("<body>", '<body style="margin:0;padding:24px">').replace(
+        str(RUN), "[capture-folder]"
+    )
+    (CAP / f"{name}.html").write_text(page, encoding="utf-8")
+
 
 class CaptureView(RichView):
     def __init__(self, answers):
-        self.answers=iter(answers)
-        self.captures=[]
-        self.sink=io.StringIO()
-        super().__init__(interactive=True,live=False,console=Console(file=self.sink,record=True,width=86,force_terminal=True))
-    def checkpoint(self,title,body,hint):
+        self.answers = iter(answers)
+        self.captures = []
+        self.sink = io.StringIO()
+        super().__init__(
+            interactive=True,
+            live=False,
+            console=Console(file=self.sink, record=True, width=86, force_terminal=True),
+        )
+
+    def checkpoint(self, title, body, hint):
         self.console.export_text(clear=True)
-        answer=next(self.answers)
-        with patch.object(self.console,'input',return_value=answer):
-            result=super().checkpoint(title,body,hint)
-        name={'The brief':'capture-checkpoint','The outline':'capture-outline','Chapter 1, read blind':'capture-chapter'}[title]
-        write_html(name,self.console)
-        self.captures.append({'title':title,'answer':answer,'capture':name})
+        answer = next(self.answers)
+        with patch.object(self.console, "input", return_value=answer):
+            result = super().checkpoint(title, body, hint)
+        name = {
+            "The brief": "capture-checkpoint",
+            "The outline": "capture-outline",
+            "Chapter 1, read blind": "capture-chapter",
+        }[title]
+        write_html(name, self.console)
+        self.captures.append({"title": title, "answer": answer, "capture": name})
         return result
 
-spec=importlib.util.spec_from_file_location('demo_builder',SOURCE/'scripts/build_reader_demo.py')
-demo=importlib.util.module_from_spec(spec);spec.loader.exec_module(demo)
-draft=demo.CHAPTERS[1][0]; accepted=demo.CHAPTERS[1][1]
-brief='A night-shift librarian finds a library card stamped with tomorrow\'s date. The name on it is her own.'
-intake=('=== FILE: ASSUMPTIONS.md ===\n# Assumptions\n\nScripted interface fixture.\n'
-        '=== FILE: artifacts/00-brief.md ===\n# Brief\n\n'+brief+'\n\nAudience: adult mystery readers.\nDirection: an intimate mystery inside a night library.\n'
-        '=== FILE: artifacts/01-market-map.md ===\n# Market map\n\nFixture material, not market research.\n'
-        '=== FILE: artifacts/02-story-engine.md ===\n# Story engine\n\nMara must discover why the date is ahead.\n'
-        '=== STATE ===\ntitle: The Lantern Index\ngenre: thriller\nlanguage: en\n')
-intake_note=intake.replace('Audience: adult mystery readers.','Author direction: Mara questions the date before touching the card.\nAudience: adult mystery readers.')
-foundation=('=== FILE: artifacts/03-characters.md ===\n# Characters\n\nMara, a cautious night librarian.\n'
-            '=== FILE: artifacts/04-theme.md ===\n# Theme\n\nWho gets to decide the next page?\n'
-            '=== FILE: artifacts/06-emotional-curve.md ===\n# Curve\n\nCuriosity becomes a choice.\n')
-outline=('=== FILE: artifacts/05-outline.md ===\n# Outline\n\n## Chapter 1: The Lantern Index\n\nMara finds the card and questions its date before the return chute clicks.\n\n## Chapter 2: The Return Chute\n\nA second card introduces a name from the past.\n'
-         '=== FILE: artifacts/07-opening-strategy.md ===\n# Opening strategy\n\nBegin with the card and a concrete unanswered question.\n')
-yes='```yaml\nturn_page: yes\nstopped_at: none\nremember:\n  - the library card stamped tomorrow\nflags: []\nvs_previous: none\nvs_anchor: none\n```\n'
-sep='\n=== NEXT ===\n'
-RUN=Path(tempfile.mkdtemp(prefix='book-genesis-video-'))
-(RUN/'new-responses.txt').write_text(sep.join([intake,intake_note,foundation,outline]),encoding='utf-8')
-(RUN/'resume-responses.txt').write_text(sep.join([draft,accepted,yes,yes,yes]),encoding='utf-8')
+
+spec = importlib.util.spec_from_file_location(
+    "demo_builder", SOURCE / "scripts/build_reader_demo.py"
+)
+demo = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(demo)
+draft = demo.CHAPTERS[1][0]
+accepted = demo.CHAPTERS[1][1]
+brief = "A night-shift librarian finds a library card stamped with tomorrow's date. The name on it is her own."
+intake = (
+    "=== FILE: ASSUMPTIONS.md ===\n# Assumptions\n\nScripted interface fixture.\n"
+    "=== FILE: artifacts/00-brief.md ===\n# Brief\n\n"
+    + brief
+    + "\n\nAudience: adult mystery readers.\nDirection: an intimate mystery inside a night library.\n"
+    "=== FILE: artifacts/01-market-map.md ===\n# Market map\n\nFixture material, not market research.\n"
+    "=== FILE: artifacts/02-story-engine.md ===\n# Story engine\n\nMara must discover why the date is ahead.\n"
+    "=== STATE ===\ntitle: The Lantern Index\ngenre: thriller\nlanguage: en\n"
+)
+intake_note = intake.replace(
+    "Audience: adult mystery readers.",
+    "Author direction: Mara questions the date before touching the card.\nAudience: adult mystery readers.",
+)
+foundation = (
+    "=== FILE: artifacts/03-characters.md ===\n# Characters\n\nMara, a cautious night librarian.\n"
+    "=== FILE: artifacts/04-theme.md ===\n# Theme\n\nWho gets to decide the next page?\n"
+    "=== FILE: artifacts/06-emotional-curve.md ===\n# Curve\n\nCuriosity becomes a choice.\n"
+)
+outline = (
+    "=== FILE: artifacts/05-outline.md ===\n# Outline\n\n## Chapter 1: The Lantern Index\n\nMara finds the card and questions its date before the return chute clicks.\n\n## Chapter 2: The Return Chute\n\nA second card introduces a name from the past.\n"
+    "=== FILE: artifacts/07-opening-strategy.md ===\n# Opening strategy\n\nBegin with the card and a concrete unanswered question.\n"
+)
+yes = "```yaml\nturn_page: yes\nstopped_at: none\nremember:\n  - the library card stamped tomorrow\nflags: []\nvs_previous: none\nvs_anchor: none\n```\n"
+sep = "\n=== NEXT ===\n"
+RUN = Path(tempfile.mkdtemp(prefix="book-genesis-video-"))
+(RUN / "new-responses.txt").write_text(
+    sep.join([intake, intake_note, foundation, outline]), encoding="utf-8"
+)
+(RUN / "resume-responses.txt").write_text(
+    sep.join([draft, accepted, yes, yes, yes]), encoding="utf-8"
+)
 os.chdir(RUN)
-project=Path('books/lantern-demo')
-if project.exists():raise SystemExit('Recording project already exists; choose a fresh capture directory.')
-view=CaptureView(['Make Mara question the date before touching the card.','','q'])
-code=session_main(['new','--idea',brief,'--language','en','--path',str(project),'--fake-responses','new-responses.txt'],view=view)
-assert code==0
-resume=CaptureView(['','q'])
-code2=session_main(['resume',str(project),'--fake-responses','resume-responses.txt'],view=resume)
-assert code2==0
-transcripts={}
-for name,args in [('capture-setup',['--help']),('capture-export',['export',str(project),'--format','epub'])]:
-    stream=io.StringIO()
-    with contextlib.redirect_stdout(stream):ret=main(args)
-    assert ret==0
-    text=stream.getvalue().replace(str(project.resolve()),'[project]');transcripts[name]={'args':args,'exit_code':ret,'output':text}
-    c=Console(file=io.StringIO(),record=True,width=94)
-    c.print('$ book-genesis '+' '.join(args),style='bold cyan')
-    c.print(text,markup=False)
-    write_html(name,c)
-    (CAP/f'{name}.txt').write_text(text,encoding='utf-8')
-transcripts['guided']={'new_exit':code,'resume_exit':code2,'checkpoints':view.captures+resume.captures,'new_output':view.sink.getvalue(),'resume_output':resume.sink.getvalue()}
-(CAP/'recording-evidence.json').write_text(json.dumps(transcripts,indent=2),encoding='utf-8')
+project = Path("books/lantern-demo")
+if project.exists():
+    raise SystemExit(
+        "Recording project already exists; choose a fresh capture directory."
+    )
+view = CaptureView(["Make Mara question the date before touching the card.", "", "q"])
+code = session_main(
+    [
+        "new",
+        "--idea",
+        brief,
+        "--language",
+        "en",
+        "--path",
+        str(project),
+        "--fake-responses",
+        "new-responses.txt",
+    ],
+    view=view,
+)
+assert code == 0
+resume = CaptureView(["", "q"])
+code2 = session_main(
+    ["resume", str(project), "--fake-responses", "resume-responses.txt"], view=resume
+)
+assert code2 == 0
+transcripts = {}
+for name, args in [
+    ("capture-setup", ["--help"]),
+    ("capture-export", ["export", str(project), "--format", "epub"]),
+]:
+    stream = io.StringIO()
+    with contextlib.redirect_stdout(stream):
+        ret = main(args)
+    assert ret == 0
+    display_args = [project.as_posix() if arg == str(project) else arg for arg in args]
+    native_export = str(project.resolve() / "exports" / "manuscript.epub")
+    text = stream.getvalue().replace(native_export, "[project]/exports/manuscript.epub")
+    transcripts[name] = {"args": display_args, "exit_code": ret, "output": text}
+    c = Console(file=io.StringIO(), record=True, width=94)
+    c.print("$ book-genesis " + " ".join(display_args), style="bold cyan")
+    c.print(text, markup=False)
+    write_html(name, c)
+    (CAP / f"{name}.txt").write_text(text, encoding="utf-8")
+transcripts["guided"] = {
+    "new_exit": code,
+    "resume_exit": code2,
+    "checkpoints": view.captures + resume.captures,
+    "new_output": view.sink.getvalue(),
+    "resume_output": resume.sink.getvalue(),
+}
+(CAP / "recording-evidence.json").write_text(
+    json.dumps(transcripts, indent=2), encoding="utf-8"
+)
 # The existing public fixture provides a second chapter and two version choices.
-demo.build(OUT/'reader',SOURCE)
-(CAP/'capture-start.html').write_text((CAP/'capture-checkpoint.html').read_text(encoding='utf-8'),encoding='utf-8')
-print(json.dumps({'new_exit':code,'resume_exit':code2,'checkpoints':len(view.captures+resume.captures),'export_exists':(project/'exports/manuscript.epub').is_file(),'captures':[p.name for p in CAP.glob('*.html')]},indent=2))
+demo.build(OUT / "reader", SOURCE)
+(CAP / "capture-start.html").write_text(
+    (CAP / "capture-checkpoint.html").read_text(encoding="utf-8"), encoding="utf-8"
+)
+print(
+    json.dumps(
+        {
+            "new_exit": code,
+            "resume_exit": code2,
+            "checkpoints": len(view.captures + resume.captures),
+            "export_exists": (project / "exports/manuscript.epub").is_file(),
+            "captures": [p.name for p in CAP.glob("*.html")],
+        },
+        indent=2,
+    )
+)


### PR DESCRIPTION
Normalize the launch subtitles to the standard EPUB spelling and make regenerated capture transcripts use portable display paths while preserving native runner arguments. Clean up the capture script's lint errors and regenerate the export evidence. This addresses the three minor comments on PR #20.

Add a first-launch packet with exact assets, ready English YouTube/LinkedIn/X copy, and a blank results sheet. No social posts are published by these files.

Validation: focused Ruff and Python compilation passed; the deterministic capture completed `new`, `resume`, five checkpoint visits, and EPUB export successfully. All subtitle timestamps remain unchanged. Independent review passed. The refreshed video-kit ZIP passes integrity checks and includes the corrected captions and launch packet. No product runtime code or dependencies changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a first-launch marketing packet with recommended publishing order, channel-ready copy, release assets, and results tracking guidance.

* **Documentation**
  * Added guidance on path formatting used in displayed transcripts and published screenshots.
  * Updated the marketing kit contents to include the first-launch packet.

* **Bug Fixes**
  * Corrected subtitle references from “E pub” to “EPUB” across long- and short-form captions.

* **Style**
  * Standardized displayed export paths with forward slashes and improved visual highlighting for export paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->