### PR TITLE
Keep human approval required when a writing session resumes

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -61,7 +61,7 @@ The guided session pauses after the brief, the outline, and a blind reading of c
 book-genesis resume books/returned-books
 ```
 
-Use `--human` to require a deliberate human approval after chapter 1. Without it, the model-reader panel runs and the session continues automatically. Use `--chapters N` for a limited run.
+Use `--human` to require a deliberate human approval after chapter 1. The choice is saved with that project, so every later `resume` continues to require `approve` even when invoked with `--yes`. Without it, the model-reader panel runs and the session continues automatically. Use `--chapters N` for a limited run.
 
 ## Read and export
 

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -29,7 +29,7 @@ python runner/cli.py validate <project>
 python runner/cli.py demo <path>                 # deterministic file-contract demo, no model
 ```
 
-`--human` additionally requires explicit approval after chapter 1. The guided terminal session also asks for decisions at the brief, outline and chapter 1 unless `--yes` or non-interactive input is used. `--manual` turns every model call into a prompt file under `work/manual/` for people who only have a chat window. In the guided session, Enter continues, a typed response becomes author notes, and `q` stops safely; `resume` continues from the saved state and reports remaining work.
+`--human` additionally requires explicit approval after chapter 1. That opt-in is saved in the project: every later `resume`, including `resume --yes`, keeps the approval requirement until `approve` records it. The guided terminal session also asks for decisions at the brief, outline and chapter 1 unless `--yes` or non-interactive input is used. `--manual` turns every model call into a prompt file under `work/manual/` for people who only have a chat window. In the guided session, Enter continues, a typed response becomes author notes, and `q` stops safely; `resume` continues from the saved state and reports remaining work.
 
 `review` writes a self-contained reading page under `review/index.html`, with chapters, version history and comparison; `--open` opens that local file. `export` writes Markdown or EPUB under `exports/` and explicitly identifies partial work. Choose `--output PATH` for another destination. Inside the project, exports stay under `exports/` to protect inputs; `--overwrite` can replace an export, never the source manuscript. Neither command uploads the book.
 

--- a/runner/book.py
+++ b/runner/book.py
@@ -9,7 +9,7 @@ from typing import Callable, Dict, List, Optional
 
 from runner.adapters import Adapter
 from runner.brief import CHAPTER_MARK
-from runner.chapter import AwaitingHuman, Judge, run_chapter
+from runner.chapter import AwaitingHuman, FIRST_CHAPTER_SLUG, Judge, resolve_human_checkpoint, run_chapter
 
 
 @dataclass
@@ -74,12 +74,18 @@ def run_book(
         raise ValueError("the outline has no `## Chapter N` headings; nothing to write")
 
     say = progress or (lambda _message: None)
+    human_checkpoint = resolve_human_checkpoint(project, requested=human_checkpoint)
     gate_chapters = set(panel_chapters if panel_chapters is not None else [1])
     first = start or 1
     last = end or total
     _validate_range(first, last, total)
     done: List[int] = []
     for number in range(first, last + 1):
+        if human_checkpoint and number > 1:
+            marker = project / "approvals" / f"{FIRST_CHAPTER_SLUG}.approved"
+            if not marker.exists():
+                waiting = AwaitingHuman(project / "manuscript" / "chapters" / f"{FIRST_CHAPTER_SLUG}.md", marker)
+                return BookResult("awaiting_human", done, number, str(waiting))
         pending_rewrite = project / "work" / f"rewrite-chapter-{number:02d}.pending"
         if (project / "manuscript" / "chapters" / f"chapter-{number:02d}.md").exists() and not pending_rewrite.exists():
             say(f"chapter {number}: already written, skipped")

--- a/runner/chapter.py
+++ b/runner/chapter.py
@@ -17,7 +17,7 @@ from typing import Callable, Dict, List, Optional, Protocol
 from runner.adapters import Adapter
 from runner.brief import TAIL_WORDS, build_chapter_brief, tail_words
 from runner.constants import GenreProfile, load_genre_profile
-from runner.filesystem import load_state_summary
+from runner.filesystem import load_state_summary, set_human_checkpoint_required
 from runner.history import load_manifest, project_relative, record_draft, reserve_attempt, sha256, write_manifest
 from runner.judge import SingleJudge, Verdict
 
@@ -98,6 +98,21 @@ def approve(project: Path, slug: str) -> Path:
     return marker
 
 
+def resolve_human_checkpoint(project: Path, *, requested: bool = False) -> bool:
+    """Return the durable human-checkpoint requirement for this project.
+
+    ``--human`` is an opt-in for a project, not only for the process that happened
+    to create its first chapter. Older projects may have been left with the
+    historical ``awaiting_human`` status before the opt-in flag existed; adopt
+    that state on the first resume so they cannot be advanced accidentally.
+    """
+    summary = load_state_summary(project)
+    required = requested or summary.get("human_checkpoint_required") == "true" or summary.get("status") == "awaiting_human"
+    if required and summary.get("human_checkpoint_required") != "true":
+        set_human_checkpoint_required(project, True)
+    return required
+
+
 def run_chapter(
     project: Path,
     chapter: int,
@@ -121,7 +136,7 @@ def run_chapter(
     """
     models = models or {}
     say = progress or (lambda _message: None)
-    if human_checkpoint and chapter > 1:
+    if resolve_human_checkpoint(project, requested=human_checkpoint) and chapter > 1:
         marker = project / "approvals" / f"{FIRST_CHAPTER_SLUG}.approved"
         if not marker.exists():
             raise AwaitingHuman(project / "manuscript" / "chapters" / f"{FIRST_CHAPTER_SLUG}.md", marker)

--- a/runner/filesystem.py
+++ b/runner/filesystem.py
@@ -169,6 +169,7 @@ def load_state_summary(target: Path) -> Dict[str, str]:
         "model_name": _extract_scalar(text, "model_name"),
         "current_phase": _extract_scalar(text, "current_phase"),
         "status": _extract_scalar(text, "status"),
+        "human_checkpoint_required": _extract_scalar(text, "human_checkpoint_required"),
     }
 
 
@@ -547,6 +548,7 @@ def _project_state_template(
         f"  current_phase: \"{first_phase}\"\n"
         "  current_gate: \"\"\n"
         "  status: \"not_started\"\n"
+        "  human_checkpoint_required: \"false\"\n"
         "  revision_iteration: 0\n\n"
         "artifacts:\n"
         "  generated: []\n\n"
@@ -562,6 +564,30 @@ def _project_state_template(
 def update_state_value(path: Path, key: str, value: str) -> None:
     """Public entry point: set the first ``key:`` scalar found in PROJECT_STATE.yaml."""
     _update_state_value(path, key, value.replace('"', "'"))
+
+
+def set_human_checkpoint_required(target: Path, required: bool) -> None:
+    """Persist the optional checkpoint, adding its field to pre-v5 project state."""
+    path = target / "PROJECT_STATE.yaml"
+    text = path.read_text(encoding="utf-8")
+    value = "true" if required else "false"
+    if _extract_scalar(text, "human_checkpoint_required"):
+        update_state_value(path, "human_checkpoint_required", value)
+        return
+
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if line.strip() != "pipeline:":
+            continue
+        for cursor in range(index + 1, len(lines)):
+            if lines[cursor] and not lines[cursor].startswith((" ", "\t")):
+                break
+            if lines[cursor].strip().startswith("status:"):
+                indent = lines[cursor][: len(lines[cursor]) - len(lines[cursor].lstrip())]
+                lines.insert(cursor + 1, f'{indent}human_checkpoint_required: "{value}"')
+                path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+                return
+    raise KeyError(f"Could not add human checkpoint state in {path}")
 
 
 def _update_state_value(path: Path, key: str, value: str) -> None:

--- a/runner/session.py
+++ b/runner/session.py
@@ -18,7 +18,7 @@ from typing import Dict, List, Optional, Protocol, Tuple
 
 from runner.adapters import AdapterError, AwaitingManual
 from runner.book import count_chapters, run_book
-from runner.chapter import AwaitingHuman
+from runner.chapter import AwaitingHuman, resolve_human_checkpoint
 from runner.filesystem import advance_phase, current_phase, load_state_summary, update_state_value
 from runner.judge import parse_verdict
 from runner.phases import DRAFTING_LABEL, recover_pending_publication, run_phase
@@ -77,6 +77,7 @@ class SessionResult:
 
 def run_session(project: Path, setup, view: View, *, yes: bool = False, human: bool = False, chapters: Optional[int] = None) -> SessionResult:
     recover_pending_publication(project)
+    human = resolve_human_checkpoint(project, requested=human)
     summary = load_state_summary(project)
     view.header(
         title=summary.get("title", ""),

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from runner import app  # type: ignore  # noqa: E402
+from runner.chapter import approve  # type: ignore  # noqa: E402
 from runner.filesystem import scaffold_project  # type: ignore  # noqa: E402
 from test_session import (  # type: ignore  # noqa: E402
     ARCHITECTURE,
@@ -81,6 +82,33 @@ class AppRoutingTests(unittest.TestCase):
         )
         self.assertEqual(0, code, msg=view.calls)
         self.assertTrue((project / "manuscript" / "chapters" / "chapter-01.md").exists())
+
+    def test_human_opt_in_survives_resume_and_yes_until_approved(self) -> None:
+        project = self.tempdir / "human-book"
+        first = app.session_main(
+            [
+                "new", "--idea", "an analyst", "--language", "en", "--path", str(project),
+                "--yes", "--human", "--fake-responses", str(self.responses(INTAKE, FOUNDATION, ARCHITECTURE, *CHAPTER_ONE)),
+            ],
+            view=RecordingView(interactive=False),
+        )
+        self.assertEqual(app.cli.EXIT_AWAITING_HUMAN, first)
+        self.assertIn('human_checkpoint_required: "true"', (project / "PROJECT_STATE.yaml").read_text(encoding="utf-8"))
+
+        bypass = app.session_main(
+            ["resume", str(project), "--yes", "--fake-responses", str(self.responses(*CHAPTER_TWO, AUDIT, SCORE, PACKAGE))],
+            view=RecordingView(interactive=False),
+        )
+        self.assertEqual(app.cli.EXIT_AWAITING_HUMAN, bypass)
+        self.assertFalse((project / "manuscript" / "chapters" / "chapter-02.md").exists())
+
+        approve(project, "chapter-01")
+        completed = app.session_main(
+            ["resume", str(project), "--yes", "--fake-responses", str(self.responses(*CHAPTER_TWO, AUDIT, SCORE, PACKAGE))],
+            view=RecordingView(interactive=False),
+        )
+        self.assertEqual(app.cli.EXIT_OK, completed)
+        self.assertTrue((project / "manuscript" / "chapters" / "chapter-02.md").exists())
 
     def test_resume_without_a_project_fails_with_a_readable_message(self) -> None:
         view = RecordingView(interactive=False)

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -98,8 +98,14 @@ class RunBookTests(unittest.TestCase):
         self.assertEqual([1], result.chapters_done)
         self.assertFalse(self.chapter_file(2).exists())
 
+        # A later low-level call cannot discard the project-level opt-in simply
+        # because it omitted the transient command-line flag.
+        result = run_book(self.project, adapters, models)
+        self.assertEqual("awaiting_human", result.status)
+        self.assertFalse(self.chapter_file(2).exists())
+
         approve(self.project, "chapter-01")
-        result = run_book(self.project, adapters, models, human_checkpoint=True)
+        result = run_book(self.project, adapters, models)
         self.assertEqual("completed", result.status)
         self.assertEqual([2], result.chapters_done)
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -9,7 +9,8 @@ import unittest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
-from runner.filesystem import scaffold_project  # type: ignore  # noqa: E402
+from runner.chapter import approve  # type: ignore  # noqa: E402
+from runner.filesystem import scaffold_project, update_state_value  # type: ignore  # noqa: E402
 from runner.roles import build_role_adapters  # type: ignore  # noqa: E402
 from runner.session import interpret, run_session, strip_leading_heading  # type: ignore  # noqa: E402
 
@@ -236,6 +237,32 @@ class SessionTests(unittest.TestCase):
         self.assertIn("stopped after 1 of 2 chapters", result.message)
         self.assertTrue((self.project / "manuscript" / "chapters" / "chapter-01.md").exists())
         self.assertFalse((self.project / "manuscript" / "chapters" / "chapter-02.md").exists())
+
+    def test_legacy_awaiting_human_state_is_adopted_and_requires_approval(self) -> None:
+        first = self.setup_with(INTAKE, FOUNDATION, ARCHITECTURE, *CHAPTER_ONE)
+        initial = run_session(self.project, first, RecordingView(), yes=True, human=True)
+        self.assertEqual("awaiting_human", initial.status)
+
+        # Mimic a pre-durable-flag project that recorded only its old status.
+        state = self.project / "PROJECT_STATE.yaml"
+        state.write_text(
+            "\n".join(
+                line for line in state.read_text(encoding="utf-8").splitlines()
+                if "human_checkpoint_required:" not in line
+            ) + "\n",
+            encoding="utf-8",
+        )
+        update_state_value(state, "status", "awaiting_human")
+
+        blocked = run_session(self.project, self.setup_with(*CHAPTER_TWO, AUDIT, SCORE, PACKAGE), RecordingView(), yes=True)
+        self.assertEqual("awaiting_human", blocked.status)
+        self.assertFalse((self.project / "manuscript" / "chapters" / "chapter-02.md").exists())
+        self.assertIn('human_checkpoint_required: "true"', state.read_text(encoding="utf-8"))
+
+        approve(self.project, "chapter-01")
+        completed = run_session(self.project, self.setup_with(*CHAPTER_TWO, AUDIT, SCORE, PACKAGE), RecordingView(), yes=True)
+        self.assertEqual("completed", completed.status)
+        self.assertTrue((self.project / "manuscript" / "chapters" / "chapter-02.md").exists())
 
 
 class StripHeadingTests(unittest.TestCase):


### PR DESCRIPTION
Starting a project with `new --human` paused after chapter 1, but `resume --yes` could continue without approval when the user omitted `--human`. The approval choice is now stored with the project and enforced by guided sessions and the lower-level chapter/book runner. Older projects saved as `awaiting_human` adopt the durable requirement on resume.

Regression coverage checks that resuming without the flag still pauses, chapter 2 is absent until `approve` is recorded, and an approved project can finish normally. Documentation explains the persistent opt-in.

Validation at `89c2065`: 39 focused tests and the complete 281-test offline suite passed on Windows/Python 3.11; Ruff and `git diff --check` passed. A separate reviewer reproduced the original failure sequence against the fixed source, confirmed it remains blocked without approval, and passed 47 focused tests plus compilation. The legacy test removes the field entirely to exercise migration of an actual older project. The GitHub Windows/Ubuntu × Python 3.10/3.12 matrix passed for both push and pull request runs. No provider call or literary-quality claim is part of this change.

Review disposition: CodeRabbit suggested treating the normal interactive checkpoint marker as the explicit human approval. An independent review confirmed that this would contradict the existing contract: `AGENTS.md` specifies that `--human` additionally requires the `approve` command. The guided checkpoint and `approvals/chapter-01.approved` intentionally represent separate decisions. No change was made for that finding; `tests/test_chapter.py` covers the explicit approval requirement.
