### PR TITLE
Add DeepSeek Harness, five more hosts, and an English launch kit

### DIFF
--- a/.github/workflows/portable-skills.yml
+++ b/.github/workflows/portable-skills.yml
@@ -21,13 +21,13 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          foreach ($target in @('claude', 'codex', 'kimi', 'openclaw', 'hermes', 'opencode', 'antigravity', 'gemini', 'shared')) {
+          foreach ($target in @('claude', 'codex', 'kimi', 'openclaw', 'hermes', 'opencode', 'antigravity', 'gemini', 'shared', 'deepseek', 'cursor', 'copilot', 'qwen', 'pi', 'windsurf')) {
             ./install.ps1 -Target $target -Destination "${{ runner.temp }}/book-genesis/$target/skills" -DryRun
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
       - name: Shell installer preview
         if: runner.os != 'Windows'
         run: |
-          for target in claude codex kimi openclaw hermes opencode antigravity gemini shared; do
+          for target in claude codex kimi openclaw hermes opencode antigravity gemini shared deepseek cursor copilot qwen pi windsurf; do
             bash install.sh "$target" --dest "$RUNNER_TEMP/book-genesis/$target/skills" --dry-run
           done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ When asked to create, plan, draft, audit, score, revise, or package a book, use 
 skills/book-genesis/SKILL.md
 ```
 
-Treat this as the current universal pipeline for Claude Code, Codex, OpenCode, Gemini CLI, Kimi Code, OpenClaw, Hermes Agent, Antigravity, and other file-aware agents. `skills/book-genesis-codex/` remains only as a compatibility package.
+Treat this as the current universal pipeline for Claude Code, Codex, DeepSeek Harness, OpenCode, Cursor, GitHub Copilot, Qwen Code, Pi, Windsurf/Cascade, Gemini CLI, Kimi Code, OpenClaw, Hermes Agent, Antigravity, and other file-aware agents. `skills/book-genesis-codex/` remains only as a compatibility package. A supported installer target does not establish complete-book acceptance; consult `docs/compatibility.md` for evidence.
 
 When the user asks for bestseller-level, market-ready, agent/editor-ready, or launch-ready work, layer the market umbrella skill on top of the universal core:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+## 2026-09-10 — DeepSeek Harness and wider agent distribution
+
+- Add DeepSeek Harness, Cursor, GitHub Copilot, Qwen Code, Pi, and Windsurf/Cascade: 15 install targets, comprising 14 named hosts and Shared.
+- Respect `DSH_HOME` (including its blank-value fallback) and `PI_CODING_AGENT_DIR`; retain custom destinations, reference integrity, and conflict backups.
+- Extend install/reinstall and wrapper verification to all targets; document official discovery conventions separately from native writing evidence.
+- Add an English [30-day launch kit](marketing/agent-native/README.md), platform drafts, demo scripts, measurement templates, and evidence gates. These are launch materials, not claims of a published video or social campaign.
+
 ## 2026-09-10 — More native hosts and recovery checks
 
 - Add OpenCode, Antigravity, and Gemini CLI installer targets; handle OpenCode custom/XDG configuration and Gemini substitute home correctly.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 **Your creativity. Your agent. Your book.**
 
-An open-source collection of writing skills that runs inside the AI agent you already use: Claude Code, Codex, OpenCode, Antigravity, Gemini CLI, Kimi Code, OpenClaw, Hermes Agent, or another file-aware agent.
+An open-source collection of writing skills for the AI agent you already use. Install into Claude Code, Codex, DeepSeek Harness, OpenCode, Cursor, GitHub Copilot, Qwen Code, Pi, Windsurf, Antigravity, Gemini CLI, Kimi Code, OpenClaw, or Hermes Agent. A shared directory target is also available.
 
 Bring an idea. Book Genesis gives your agent a workflow for developing it into a manuscript: direction, characters, outline, chapters, editorial review, revision, and a publishing package. You keep the project files and creative decisions.
 
-[MIT license](LICENSE) · [Installation guide](docs/portability.md) · [Writing skills](skills/book-genesis/SKILL.md) · [Project casebook](SHOWCASE.md)
+[MIT license](LICENSE) · [Installation guide](docs/portability.md) · [Compatibility evidence](docs/compatibility.md) · [Launch kit](marketing/agent-native/README.md) · [Project casebook](SHOWCASE.md)
+
+**New: six more install targets.** DeepSeek Harness, Cursor, GitHub Copilot, Qwen Code, Pi, and Windsurf receive the same 15-skill bundle. There are now **15 installation targets: 14 named hosts plus Shared**. Installation and file integrity are tested; native writing acceptance is tracked separately in the compatibility table.
 
 ## Back to the skills
 
@@ -35,6 +37,12 @@ python runner/cli.py install hermes
 python runner/cli.py install opencode
 python runner/cli.py install antigravity
 python runner/cli.py install gemini
+python runner/cli.py install deepseek
+python runner/cli.py install cursor
+python runner/cli.py install copilot
+python runner/cli.py install qwen
+python runner/cli.py install pi
+python runner/cli.py install windsurf
 ```
 
 PowerShell and shell shortcuts are also included:
@@ -91,9 +99,17 @@ The same [15-skill suite](distribution/portable-suite.json) goes to every suppor
 | OpenCode | `~/.config/opencode/skills/` |
 | Antigravity | `~/.gemini/config/skills/` |
 | Gemini CLI | `~/.gemini/skills/` |
+| DeepSeek Harness | `~/.dsh/skills/` |
+| Cursor | `~/.cursor/skills/` |
+| GitHub Copilot | `~/.copilot/skills/` |
+| Qwen Code | `~/.qwen/skills/` |
+| Pi | `~/.pi/agent/skills/` |
+| Windsurf / Cascade | `~/.codeium/windsurf/skills/` |
 | Shared Agent Skills | `~/.agents/skills/` via `install shared` |
 
 Host-specific home variables and `--dest` override these locations. OpenCode also respects `XDG_CONFIG_HOME`; its explicit `OPENCODE_CONFIG_DIR` takes priority. The OpenClaw and Hermes destinations follow their official [OpenClaw](https://docs.openclaw.ai/tools/skills) and [Hermes](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) skill-directory conventions. Installer compatibility is tested separately from live writing in those hosts.
+
+DeepSeek Harness respects `DSH_HOME`; Pi respects `PI_CODING_AGENT_DIR`. See [the six new host setup notes and official sources](docs/portability.md#deepseek-harness-cursor-copilot-qwen-pi-and-windsurf). The package is MIT licensed. Model usage may have a cost or quota under your host account.
 
 ## The work behind it
 

--- a/distribution/portable-suite.json
+++ b/distribution/portable-suite.json
@@ -75,6 +75,37 @@
       "home_env": "HERMES_HOME",
       "default_home": ".hermes",
       "skills_dir": "skills"
+    },
+    "deepseek": {
+      "home_env": "DSH_HOME",
+      "ignore_blank_home": true,
+      "default_home": ".dsh",
+      "skills_dir": "skills"
+    },
+    "cursor": {
+      "home_env": "",
+      "default_home": ".cursor",
+      "skills_dir": "skills"
+    },
+    "copilot": {
+      "home_env": "",
+      "default_home": ".copilot",
+      "skills_dir": "skills"
+    },
+    "qwen": {
+      "home_env": "",
+      "default_home": ".qwen",
+      "skills_dir": "skills"
+    },
+    "pi": {
+      "home_env": "PI_CODING_AGENT_DIR",
+      "default_home": ".pi/agent",
+      "skills_dir": "skills"
+    },
+    "windsurf": {
+      "home_env": "",
+      "default_home": ".codeium/windsurf",
+      "skills_dir": "skills"
     }
   }
 }

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -13,8 +13,14 @@ Checked September 10, 2026. Every installer target receives the same 15 writing 
 | Antigravity | Passed | CLI v1.1.27: real intake wrote six files; fresh read-only session recovered the next phase; targeted native edits corrected state and evidence labels |
 | Gemini CLI | Passed | v0.56.0 `gemini skills list`: all 15 enabled from isolated user home |
 | Shared Agent Skills | Passed | Generic directory export; discovery depends on the consuming host |
+| DeepSeek Harness | Passed | Official paths/source checked; no fresh native run |
+| Cursor | Passed | Official paths checked; no fresh native run |
+| GitHub Copilot | Passed | Official paths checked; no fresh native run |
+| Qwen Code | Passed | Official paths checked; no fresh native run |
+| Pi | Passed | Official paths/source checked; no fresh native run |
+| Windsurf / Cascade | Passed | Official paths checked; no fresh native run |
 
-The regression suite verifies all nine targets through the Python CLI: preview, actual copying, reference integrity, and reinstall. CI runs the suite on Windows, Linux, and macOS with Python 3.10 and 3.12, plus installer wrapper previews. CI tests do not start commercial models. See the [recorded host observations](host-verification-20260910.json).
+The regression suite verifies all 15 targets through the Python CLI: preview, actual copying, reference integrity, and reinstall. CI runs the suite on Windows, Linux, and macOS with Python 3.10 and 3.12, plus installer wrapper previews. CI tests do not start commercial models. See the [recorded earlier host observations](host-verification-20260910.json) and [new host setup sources](portability.md#deepseek-harness-cursor-copilot-qwen-pi-and-windsurf). The historical JSON predates the six-target expansion; it is not evidence of live runs in the new hosts.
 
 ## Antigravity findings
 

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -1,6 +1,6 @@
 # Portability
 
-Book Genesis is an Agent Skills package, not a hosted model wrapper. Claude Code, Codex, OpenCode, Antigravity, Gemini CLI, Kimi Code, OpenClaw, and Hermes Agent install the same canonical skill folders and execute them with their own accounts, models, permissions, and quotas.
+Book Genesis is an Agent Skills package. All 15 installation targets receive the same canonical skill folders. The consuming host executes them with its own account, models, permissions, and quotas. The target list contains 14 named hosts and one Shared directory export.
 
 ## Canonical Package
 
@@ -32,6 +32,12 @@ bash install.sh opencode
 bash install.sh antigravity
 bash install.sh gemini
 bash install.sh shared
+bash install.sh deepseek
+bash install.sh cursor
+bash install.sh copilot
+bash install.sh qwen
+bash install.sh pi
+bash install.sh windsurf
 ```
 
 Windows PowerShell:
@@ -46,6 +52,12 @@ Windows PowerShell:
 .\install.ps1 -Target antigravity
 .\install.ps1 -Target gemini
 .\install.ps1 -Target shared
+.\install.ps1 -Target deepseek
+.\install.ps1 -Target cursor
+.\install.ps1 -Target copilot
+.\install.ps1 -Target qwen
+.\install.ps1 -Target pi
+.\install.ps1 -Target windsurf
 ```
 
 Default user locations:
@@ -61,6 +73,12 @@ Default user locations:
 | Antigravity | `~/.gemini/config/skills/` | ask Antigravity to use `book-genesis` |
 | Gemini CLI | `$GEMINI_CLI_HOME/.gemini/skills/` or `~/.gemini/skills/` | ask Gemini to activate `book-genesis` |
 | Shared | `~/.agents/skills/` | runtime-dependent |
+| DeepSeek Harness | `$DSH_HOME/skills/` or `~/.dsh/skills/` | ask the harness to load `book-genesis` |
+| Cursor | `~/.cursor/skills/` | ask Agent to use `book-genesis` |
+| GitHub Copilot | `~/.copilot/skills/` | ask Copilot to use `book-genesis` |
+| Qwen Code | `~/.qwen/skills/` | `/book-genesis`, or ask Qwen to use it |
+| Pi | `$PI_CODING_AGENT_DIR/skills/` or `~/.pi/agent/skills/` | `/skill:book-genesis` |
+| Windsurf / Cascade | `~/.codeium/windsurf/skills/` | `@book-genesis`, or ask Cascade to use it |
 
 Use `--dest PATH` with the Python command for an isolated or project-specific skills directory:
 
@@ -139,3 +157,37 @@ Antigravity's current global directory is `~/.gemini/config/skills`. Older editi
 After installing, run `python runner/cli.py verify-install TARGET` with the same `--dest`, if any. A changed checkout or locally edited skill will be reported as different; inspect before replacing it. This command performs no model calls. The host must still discover and activate the skill. [Compatibility evidence](compatibility.md) separates those checks.
 
 A skills-only installation contains the startup/recovery contract and initial state template under `book-genesis/references/pipeline/`. Native agents can initialize and resume a book without the repository Python helper. Optional external marketing or image skills are not required to write.
+
+## DeepSeek Harness, Cursor, Copilot, Qwen, Pi, and Windsurf
+
+Added September 10, 2026, against official host documentation and source. These are native skill installations. DeepSeek Harness is a separate product from the DeepSeek model API; installing this target does not configure an API provider inside a different agent.
+
+```bash
+python runner/cli.py install deepseek --dry-run
+python runner/cli.py install deepseek
+python runner/cli.py verify-install deepseek
+```
+
+Open a fresh DeepSeek Harness session in a writable book folder. Ask it to locate `book-genesis`, read its phase manifest and host contract, and save the intake artifacts before continuing. The same steps apply to the other targets with the appropriate host and target name.
+
+| Host | Configuration and discovery notes | Official reference |
+| --- | --- | --- |
+| DeepSeek Harness | Default `~/.dsh/skills`; `DSH_HOME` overrides the home. Empty or whitespace-only values use the default. Project `.dsh/skills` and `.agents/skills` are also supported. Explicit harness provider configuration can override the home; use `--dest` to match it. | [Skills subsystem](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/subsystems/skills.md), [home resolver](https://github.com/deepseek-ai/deepseek-harness/blob/master/packages/util/home-paths/src/index.ts) |
+| Cursor | User `.cursor/skills`, project `.cursor/skills`, and Agent Skills directories. Local user skills are not automatically copied into cloud or remote agent environments. | [Cursor skills](https://cursor.com/docs/skills) |
+| GitHub Copilot | User `.copilot/skills`; project `.github/skills` is also supported. `COPILOT_SKILLS_DIRS` is a list of additional search paths, not a replacement home. In Copilot CLI, use `copilot skill list`; `/skills reload` refreshes an active session. | [Copilot skills](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-skills) |
+| Qwen Code | User `.qwen/skills` or project `.qwen/skills`; inspect `/skills` in the host. | [Qwen skills](https://github.com/QwenLM/qwen-code/blob/main/docs/users/features/skills.md) |
+| Pi | User `.pi/agent/skills`; `PI_CODING_AGENT_DIR` replaces `.pi/agent`. Project `.pi/skills` is available. | [Pi skills](https://pi.dev/docs/latest/skills), [configuration source](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/src/config.ts) |
+| Windsurf / Cascade | User `.codeium/windsurf/skills` or project `.windsurf/skills`. The official documentation redirects to Devin Desktop; this target does not claim compatibility with Devin cloud's separate skill system. | [Cascade skills](https://docs.devin.ai/desktop/cascade/skills) |
+
+For project or remote installations, pass the actual skills directory to `--dest`, for example:
+
+```bash
+python runner/cli.py install deepseek --dest /path/to/book/.dsh/skills
+python runner/cli.py install cursor --dest /path/to/book/.cursor/skills
+python runner/cli.py install copilot --dest /path/to/book/.github/skills
+python runner/cli.py install qwen --dest /path/to/book/.qwen/skills
+python runner/cli.py install pi --dest /path/to/book/.pi/skills
+python runner/cli.py install windsurf --dest /path/to/book/.windsurf/skills
+```
+
+Run the installer where the host reads files. Avoid installing the same suite into several directories searched by the same host. Check discovery after an update, including possible duplicate skills from custom recursive search configurations. Host commands, trust settings, and release behavior can change; the [compatibility table](compatibility.md) records what was actually exercised.

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [ValidateSet("claude", "codex", "kimi", "openclaw", "hermes", "shared", "opencode", "antigravity", "gemini")]
+    [ValidateSet("claude", "codex", "kimi", "openclaw", "hermes", "shared", "opencode", "antigravity", "gemini", "deepseek", "cursor", "copilot", "qwen", "pi", "windsurf")]
     [string]$Target = "claude",
     [string]$Destination = "",
     [switch]$Force,

--- a/install.sh
+++ b/install.sh
@@ -5,9 +5,9 @@ repo_dir="$(cd "$(dirname "$0")" && pwd)"
 target="${1:-claude}"
 
 case "$target" in
-  claude|codex|kimi|openclaw|hermes|shared|opencode|antigravity|gemini) ;;
+  claude|codex|kimi|openclaw|hermes|shared|opencode|antigravity|gemini|deepseek|cursor|copilot|qwen|pi|windsurf) ;;
   *)
-    echo "Usage: ./install.sh [claude|codex|kimi|openclaw|hermes|shared|opencode|antigravity|gemini] [--dest PATH] [--dry-run] [--force] [--include-legacy]" >&2
+    echo "Usage: ./install.sh [claude|codex|kimi|openclaw|hermes|shared|opencode|antigravity|gemini|deepseek|cursor|copilot|qwen|pi|windsurf] [--dest PATH] [--dry-run] [--force] [--include-legacy]" >&2
     exit 2
     ;;
 esac

--- a/marketing/agent-native/README.md
+++ b/marketing/agent-native/README.md
@@ -1,0 +1,43 @@
+# Book Genesis: agent-native launch kit
+
+Prepared September 10, 2026. English copy for Felipe Lobo and contributors. These files are a plan and drafts; they do not mean that social posts, videos, directory listings, or an automated campaign have been published.
+
+**Your creativity. Your agent. Your book.**
+
+Book Genesis gives the AI agent you already use a structured writing workflow. The package is MIT licensed; your host account supplies the models, tools, permissions, and any usage costs. Your project stays in files you control, subject to how your chosen host processes those files.
+
+## Start here
+
+1. Read the [launch plan](launch-plan.md), especially the evidence gates.
+2. Record a real installation, saved chapter, and fresh-session resume using the [demo scripts](demo-scripts.md).
+3. Adapt the [platform copy](platform-copy.md) in your own voice and review it against the current compatibility table.
+4. Work through the [30-day calendar](calendar.csv). Day 1 starts when you choose; nothing is scheduled automatically.
+5. Record aggregate outcomes in the [metrics template](metrics.csv). The [baseline](baseline.json) separates observed repository attention from unknown product adoption.
+
+## The public promise
+
+Use: **“Turn your book idea into a manuscript with the AI agent you already use.”**
+
+Support it with an actual example: idea, outline, saved prose, an identified weakness, a revision, and recovery in a fresh session. “15 installation targets” means 14 named hosts plus a Shared directory; it does not mean 15 certified complete-book engines. There are also 15 writing skills in the bundle, a separate count.
+
+The current product is the portable skills package. Historical standalone-app screenshots, old model scoreboards, and simulated runner demos must be labeled with their actual context. A book being drafted is not automatically a professionally edited book, and no tool can establish bestseller sales in advance.
+
+## Founder voice
+
+Speak plainly, show the work, and thank people who find problems. The documented story is enough: you like coding and inventing things, tried a broader app, encountered reliability and usability problems, and chose to focus again on skills inside the agents people already use. You want creativity to be the starting point and want this project to grow. Do not invent personal hardship, credentials, customers, or reader testimonials.
+
+Suggested short bio: “I'm Felipe. I like coding, making things, and seeing how far an idea can go. I'm building Book Genesis in public so more people can explore the book they want to write.”
+
+## Asset inventory
+
+| Asset | State |
+| --- | --- |
+| Installation guide and host evidence | In the repository; link to the current revision |
+| Platform posts, founder story, Product Hunt draft | Written; review before posting |
+| 60-second clip and longer walkthrough | Scripts ready; fresh recording required |
+| Carousel | Slide copy ready; visual production required |
+| 30-day calendar and measurement sheet | Templates ready; no automation configured |
+| External-reader quotes and author showcase | Collect only with permission; none invented here |
+| skills.sh distribution listing | Candidate channel; dedicated package/install verification still needed |
+
+The first asset to produce is the real walkthrough. It is the evidence behind every shorter post.

--- a/marketing/agent-native/baseline.json
+++ b/marketing/agent-native/baseline.json
@@ -1,0 +1,29 @@
+{
+  "observed_date": "2026-09-10",
+  "source": "GitHub repository REST API; repository attention snapshot, not an active-user or growth-rate ranking",
+  "project": {
+    "repository": "felipelobomotta-blip/book-genesis-v4",
+    "url": "https://github.com/felipelobomotta-blip/book-genesis-v4",
+    "stars": 114,
+    "forks": 38,
+    "open_items_including_pull_requests": 12,
+    "measured_installs": null,
+    "activated_projects": null,
+    "seven_day_returning_users": null
+  },
+  "ecosystem_attention": [
+    {"repository": "deepseek-ai/deepseek-harness", "stars": 218623, "created_at": "2026-08-13T11:56:32Z"},
+    {"repository": "earendil-works/pi", "stars": 103730},
+    {"repository": "QwenLM/qwen-code", "stars": 27743},
+    {"repository": "github/copilot-cli", "stars": 11152}
+  ],
+  "planning_targets_30_days_not_forecasts": {
+    "observed_pilot_attempts": 10,
+    "successful_pilot_chapter_and_resume_journeys": 8,
+    "activated_projects_total": 30,
+    "users_returning_after_at_least_seven_days": 10,
+    "permission_based_examples": 5,
+    "stretch_stars_total": 300
+  },
+  "publication_state": "Plan and drafts only; no social campaign or new video published by this kit"
+}

--- a/marketing/agent-native/calendar.csv
+++ b/marketing/agent-native/calendar.csv
@@ -1,0 +1,31 @@
+day,focus,action,channel,completion_criterion,status
+1,Proof,Choose host and record clean installation,Internal,Host version and commit logged,planned
+2,Proof,Record intake and save a real first chapter,Internal,Actual non-template chapter inspected,planned
+3,Recovery,Record fresh-session resume and repair blockers,Internal,Next step recovered from saved files,planned
+4,Pilot,Invite willing testers through appropriate existing contacts,Direct,Ten pilot attempts arranged or recruitment gap logged,planned
+5,Pilot,Observe first five installation and chapter attempts,Internal,Successes and failures recorded privately,planned
+6,Pilot,Observe remaining five attempts and prioritize blockers,Internal,Ten attempts recorded or launch held,planned
+7,Editorial proof,Complete sample short book and request two independent readings,Internal,Run evidence saved and readers invited,planned
+8,Demo,Edit factual walkthrough and label time cuts,YouTube,Draft clip reviewed against real artifacts,planned
+9,Founder story,Publish founder story with working repository link,LinkedIn,Live URL verified if posted,planned
+10,Demo distribution,Publish walkthrough and one short excerpt,YouTube,Live video verified and baseline analytics recorded,planned
+11,Hook experiment A,Share coding-agent-to-book hook with actual clip,X,Post URL and observation window recorded,planned
+12,Technical explanation,Publish portable-workflow article,DEV,Current publication policy checked and article verified,planned
+13,Community feedback,Share a useful host-specific example where permitted,One community,Rules checked and resulting feedback logged,planned
+14,Weekly decision,Review pilot and reader feedback plus activation,Internal,Broad-launch gate passed or deferred,planned
+15,Hook experiment B,Share idea-to-chapter hook in comparable format,X,Comparable observation window recorded,planned
+16,Short clip,Adapt a real revision example for vertical video,Shorts Reels TikTok,Readable native edits reviewed and live URLs logged,planned
+17,Creator outreach,Identify five relevant creators and personalize invitations,Direct,Only permitted individual contact routes used,planned
+18,Host tutorial,Record the most-requested additional host,YouTube or GitHub,Actual discovery and writing evidence recorded,planned
+19,Launch preparation,Prepare real gallery and maker comment,Product Hunt,Proof gate and current submission requirements checked,planned
+20,Conditional launch,Launch Product Hunt only if ready and support is available,Product Hunt,Live listing verified or reason for delay logged,planned
+21,Conditional technical launch,Founder independently writes appropriate Show HN submission,Hacker News,Human-written text and guidelines checked or launch deferred,planned
+22,User outcome,Request permission to feature one actual author example,Direct,Scope of excerpt and attribution permission recorded,planned
+23,User story,Publish permitted sample with honest editing notes,LinkedIn and GitHub,Permission and live URL verified,planned
+24,Retention,Check seven-day return usage for eligible participants,Internal,Eligible denominator and observed returns recorded,planned
+25,Product improvement,Fix the most frequent remaining first-session blocker,GitHub,Reproduction and fix verification published,planned
+26,Demonstrate improvement,Record the fixed journey in the affected host,X or YouTube,Before and after evidence accurately labeled,planned
+27,Sharing,Invite optional author case studies without manuscript promotion insertion,GitHub,Consenting examples counted with no invented testimonials,planned
+28,Distribution review,Assess curated skills.sh package feasibility,Internal,Canonical reference-complete install verified or left pending,planned
+29,Measurement,Compare channels by activated and returning projects,Internal,Unknown metrics left blank and decisions written,planned
+30,Public report,Publish month-one outcomes failures and next priorities,GitHub and LinkedIn,Aggregates supported by records and next-month scope chosen,planned

--- a/marketing/agent-native/demo-scripts.md
+++ b/marketing/agent-native/demo-scripts.md
@@ -1,0 +1,59 @@
+# Record a real demonstration
+
+Status: recording scripts and shot list. No video has been produced by this kit. Historical videos in the repository may show a different product version.
+
+## Prepare the capture
+
+Use a clean, writable demonstration folder and a host you can actually access. Record the commit, OS, host/version, model if known, and whether this is a subscription or other model setup. Hide credentials and personal paths. Show readable text at normal playback size; a terminal at 150% or larger is better than an unreadable full desktop.
+
+Use a fictional idea that is safe to publish:
+
+> Use the book-genesis skill. Write in English. My idea is a mystery about a retired train dispatcher who finds a farewell letter inside a station clock. Help me choose a direction and make a three-chapter short story, aiming for about 1,000 words per chapter. Save the project state and artifacts. Start with the intake and ask me about the major creative decisions.
+
+This is a **short-story demonstration**, not a full-length book benchmark. Use a separate, appropriately sized run for any complete-book claim.
+
+Capture the real commands, selecting the tested target:
+
+```bash
+git clone https://github.com/felipelobomotta-blip/book-genesis-v4.git
+cd book-genesis-v4
+python runner/cli.py verify-suite
+python runner/cli.py install deepseek
+python runner/cli.py verify-install deepseek
+```
+
+The example names DeepSeek because it is the new integration; it must be exercised natively before using DeepSeek footage or claiming a successful writing run. Select another verified host for the first recording if necessary. The installer cannot prove native writing by itself.
+
+## Sixty-second cut
+
+| Time | Picture | Suggested narration |
+| --- | --- | --- |
+| 0–5s | Idea on screen, then the chosen real agent | “You already have an AI agent. What if you used it to work on your book idea?” |
+| 5–13s | Actual install and verification result; host name visible | “Book Genesis adds a writing workflow to the agent you already use.” |
+| 13–24s | Paste the idea; show one actual creative decision | “Start with your idea. Choose the direction.” |
+| 24–37s | Actual saved outline and chapter file | “Develop the outline and save the writing in your project.” |
+| 37–47s | A concrete editorial criticism and the resulting changed passage | “Then read critically and revise the parts that need work.” |
+| 47–55s | Fresh host session reads the saved state and identifies next step | “Here is the project continuing in a new session.” |
+| 55–60s | Repository URL and simple call to action | “It's open source. Try a chapter and help me improve it.” |
+
+Only use the review and recovery lines if the recording actually demonstrates them. Capture long waits normally, then label shortened sections “edited for time” and display actual elapsed time in the description. Do not invent token streams, agent activity, reader reactions, or hidden reasoning. Visible host status and actual writing are sufficient.
+
+If only intake succeeds, publish a clearly titled intake demonstration and report the unfinished part. Do not assemble unrelated outputs into an apparent uninterrupted success.
+
+## Three-to-five-minute walkthrough
+
+1. **0:00–0:25:** Show what the package is, the target host/version, and the limited demo goal.
+2. **0:25–1:05:** Install, verify, and confirm the host discovered the skill. Explain prerequisites in one sentence.
+3. **1:05–1:50:** Start from the sample idea and show one meaningful choice the author makes.
+4. **1:50–2:40:** Open the real outline and chapter file. Show where they are saved. Include actual elapsed writing time as an overlay.
+5. **2:40–3:25:** Show one weakness found during review and the specific revision. Do not present a model score as reader approval.
+6. **3:25–4:15:** End the session, begin another in the same folder, and ask it to read state and continue. Keep the evidence of the new session visible.
+7. **4:15–4:45:** Explain any failure, quota, permission prompt, or unresolved issue. Invite a first-chapter test and link the host evidence table.
+
+Suggested capture formats: a 1920×1080 horizontal master and a separately framed 1080×1920 vertical cut. These are production choices, not mandatory platform limits. Add accurate captions. Keep keyboard text and manuscript excerpts large enough to read.
+
+## Acceptance record
+
+Before uploading, record the tested commit; host/version; date; goal; actual files; word count; elapsed time; whether installation, chapter saving, and fresh-session recovery succeeded; what was edited out; and the exact public URL after upload. Obtain permission for anything written by a tester. Leave failed steps in the evidence record even if the shorter clip focuses on the working section.
+
+Required screenshots: actual installation result, saved chapter beside project files, and fresh-session state recovery. Product Hunt needs its own correctly sized gallery assets; check its current preparation guide before export. This kit's carousel is copy only until those visuals are made.

--- a/marketing/agent-native/launch-plan.md
+++ b/marketing/agent-native/launch-plan.md
@@ -1,0 +1,100 @@
+# A 30-day launch plan built around people finishing a first chapter
+
+## Objective and positioning
+
+Help a new user save a chapter they want to keep, return in a fresh session, and continue writing. That is the first useful adoption milestone. Stars and impressions help distribution but cannot establish that the product works for writers.
+
+Core message: **Your creativity. Your agent. Your book.** The specific hook is: **Your coding agent can help you write a book.** The initial call to action is: “Try one chapter and tell me where the process breaks.”
+
+Start with people who already use coding agents and have a story, guide, or nonfiction idea. They already understand installation and host accounts. Invite curious beginners into supported pilots next. Reach professional authors through actual manuscript examples and candid editorial feedback; do not lead with a promise to replace their craft.
+
+Keep Book Genesis as the name for this campaign. Call the update “More agents, one writing workflow.” A new brand would add another recognition problem before the product has demonstrated retention.
+
+## Which integrations deserve attention
+
+The September 10 repository snapshot is in [baseline.json](baseline.json). GitHub stars are a dated attention proxy, not an active-user count or growth-rate ranking.
+
+| Priority | Integration | Why test this audience | Evidence and limitation |
+| --- | --- | --- | --- |
+| 1 | DeepSeek Harness | New official harness gives the requested launch hook a concrete technical basis | [Official developer preview](https://www.deepseek.com/harness/en/) and [repository](https://github.com/deepseek-ai/deepseek-harness); 218,623 stars in the snapshot, created August 13, 2026. New install target, no fresh native book run. |
+| 1 | Existing Claude Code and Codex users | Fits the project's existing workflow and the founder's experience | Audience-fit hypothesis, not a measured acquisition ranking. Record a current chapter/resume demonstration. |
+| 2 | Pi and Qwen Code | Agent communities are plausible early testers of a portable skills package | [Pi](https://github.com/earendil-works/pi): 103,730 stars; [Qwen Code](https://github.com/QwenLM/qwen-code): 27,743 at the snapshot. Install targets added; native book acceptance remains open. |
+| 2 | Cursor and GitHub Copilot | Reach people who prefer an editor or existing development workflow | Official skill support: [Cursor](https://cursor.com/docs/skills), [Copilot](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-skills). Reach is a hypothesis; local installation does not imply remote-agent setup. |
+| 3 | Windsurf/Cascade, OpenCode, Antigravity, Gemini, Kimi, OpenClaw, Hermes | Useful choice and targeted community demonstrations | Keep a specific host setup page and evidence row. Prioritize requests from actual users over another logo. |
+
+The next distribution experiment should be a verified, curated skills.sh package, not dozens of speculative wrappers. Its [directory](https://www.skills.sh/docs) is a relevant discovery channel for Agent Skills. Its install metrics come from its own CLI telemetry; our Python installations do not automatically count there. Test that only the canonical 15 skills and complete references are installed before advertising any new one-command marketplace instruction. No listing is claimed in this release.
+
+## Proof gates before a broad launch
+
+Use a small, clearly labeled writing pilot while these gates are open. Hold the broad Product Hunt/Show HN push until they pass.
+
+- A clean machine or clean profile can follow the README without the founder fixing files manually.
+- Ten external users attempt the same first-chapter journey; at least eight save a non-template chapter and resume correctly in a fresh session. Record all attempts, including failures. This small pilot is a usability screen, not a population reliability estimate.
+- No observed lost or overwritten manuscript content remains unresolved. Stop promotion and investigate a data-loss report immediately.
+- Record one complete short-book run with target length, actual word count, chapter count, review, revision, timing, host/model, and interruptions. Label it a short book; do not imply full-length reliability from it.
+- Two independent humans read a permitted sample without being shown an internal model score. Ask what they remember, where they stopped, and what would make them continue. Report mixed feedback as mixed feedback.
+- Publish a real installation-to-artifact walkthrough and its limits. Any cut around a wait must be labeled. Record the chapter/resume segment before claiming it in post copy.
+
+Passing these gates supports a credible skills launch. A separate repeated full-length manuscript benchmark is still needed before promising dependable full-length production.
+
+## Thirty days, in four phases
+
+**Days 1–7: make the proof easy to inspect.** Capture a current host demonstration, recruit ten willing pilot users, observe installation and resume, fix the biggest common blocker, and finish the sample short book. Have readers assess the sample. Produce one 3–5 minute walkthrough, one 60-second cut, and three real screenshots. If the pilot fails, repeat the failed journey before buying reach or scheduling a large launch.
+
+**Days 8–14: learn which message brings writers.** Post the founder story on LinkedIn, show the real workflow on X, publish the walkthrough on YouTube, and adapt two short clips for Shorts/Reels/TikTok. Answer questions personally. Publish a technical explanation on DEV. Share in at most one or two relevant communities after checking their rules. Ask users which agent they use and whether they reached a saved chapter.
+
+**Days 15–21: broaden only after the proof gate.** Prepare Product Hunt and let the founder write a Show HN submission independently. Send up to five relevant, personalized creator invitations during the week where contact is welcome. Publish a host tutorial requested by pilot users and an example of a revision improving a specific paragraph. Do not repost the same launch everywhere at once; leave time to support each audience.
+
+**Days 22–30: make user outcomes the story.** Share permitted author examples, review second-session usage, improve the largest remaining friction point, publish a candid month-one report, and decide which two channels and hosts deserve another month. Keep all calendar entries conditional on evidence; missing a date is preferable to promoting an unverified workflow.
+
+The [calendar](calendar.csv) provides one concrete action and completion criterion per day. Suggested daily time budget: 40 minutes supporting users, 30 minutes producing or adapting one asset, and 20 minutes collecting feedback and metrics. Reserve separate development time for fixes. If support exceeds capacity, reduce posting frequency.
+
+## Channel execution
+
+| Channel | What to publish | Initial cadence | Action to request |
+| --- | --- | --- | --- |
+| GitHub | Clear install guide, evidence table, sample, concise release note; issues for actual problems | One release/update per meaningful change | Try a chapter; include host and reproduction steps in feedback |
+| X | Actual clip, founder notes, a failed attempt and fix, host-specific walkthrough | Three useful posts a week; one thread in launch week | Try it with an existing agent |
+| LinkedIn | Founder story, what simplification changed, permitted user result | Two posts a week | Share the book idea or report setup friction |
+| YouTube | Searchable 3–5 minute tutorial and measured follow-up | One walkthrough, then one evidence-based follow-up | Follow the README and attempt the same journey |
+| Shorts / Reels / TikTok | Native vertical cuts of the real demo; readable captions | Two distinct clips a week, adapted per platform | Visit the profile/repository link where supported |
+| DEV | Technical article on portable skills, saved state, and honest evaluation | One substantial article, update after feedback | Inspect the repo and test a host |
+| Reddit / agent communities | A useful host-specific demonstration and frank limitations | One or two relevant communities initially | Feedback on the specific workflow |
+| Product Hunt | Working package, real screenshots, maker comment, walkthrough | One launch when the gate passes | Try the product and give feedback |
+| Hacker News | Founder-written account of the working project and technical tradeoffs | One appropriate submission after the gate | Let readers explore and discuss naturally |
+
+Community candidates include agent-specific forums, r/LocalLLaMA, r/SideProject, and r/opensource. This is a research shortlist, not confirmation that a promotional post is allowed. Check the current community rules and recent moderator guidance before writing or posting; Reddit's [spam policy](https://support.reddithelp.com/hc/en-us/articles/360043504051-Spam) does not grant a universal self-promotion allowance. Participate where the project answers a real question.
+
+Product Hunt supports maker submissions and recommends preparation around a real product; ask for feedback rather than votes. Its product URL should be the direct project URL, without a shortened or tracking link. See the [launch guide](https://www.producthunt.com/launch/preparing-for-launch). Do not purchase votes or pay someone for a promised ranking.
+
+Hacker News prohibits generated or AI-edited post text. This kit deliberately supplies no HN submission draft. The founder must write that submission and replies independently, after reading the [guidelines](https://news.ycombinator.com/newsguidelines.html) and [Show HN requirements](https://news.ycombinator.com/showhn.html). Do not request coordinated votes or comments.
+
+## A sharing loop worth earning
+
+One person has an idea, saves a chapter, improves a weak passage, and chooses to show that result. Link the permitted result to a reproducible host setup. A second person recognizes their own idea in the process and tries it. The shareable object is an author's outcome, not an internal score badge.
+
+Offer an optional “Made with Book Genesis” credit and a short case-study format: idea, host/model, version, sample excerpt, what the author changed, what still needs editing, and link. Never insert promotional text into someone's manuscript without their choice. Obtain permission for excerpts, names, images, and testimonials; allow anonymous feedback. Keep private manuscripts and participant-level tracking outside the public repository.
+
+For creators, select people who already teach a supported agent or document writing workflows. Score relevance, quality of actual demos, engaged discussion, and whether they welcome submissions. Five carefully chosen invitations are more useful than a mass mailing. Offer a reproducible example and invite criticism; do not request praise or a paid endorsement disguised as a review. Outreach copy is in the [platform kit](platform-copy.md); nothing has been sent.
+
+## Measurement and decisions
+
+The repository snapshot started at **114 stars and 38 forks**. We have no measured install count, activated-author count, or retention baseline. Leave unknowns blank in [metrics.csv](metrics.csv); never turn unknown into zero or infer installations from stars.
+
+The funnel is: platform impressions → project visits → reported install attempts → a saved first chapter → a successful fresh-session resume → use again at least seven days later → an optional public share. Record unique consenting pilot participants privately, not their manuscripts. Publish only aggregates. Count “activated” only after both chapter and fresh-session resume are confirmed by participant feedback or a permitted observation.
+
+Use native platform analytics for impressions, views, watch time, profile visits, and clicks when available. Record missing data as unavailable. Ask an optional “Where did you hear about this?” question for attribution. GitHub query strings alone do not give campaign analytics. If a measured landing page is introduced later, disclose its analytics and use consistent campaign tags there; do not invent attribution from the current repository.
+
+**Thirty-day planning targets, not forecasts:** 10 observed pilot attempts with 8 successful chapter/resume journeys; 30 total activated projects; 10 users who return after at least seven days; 5 permission-based examples. A stretch goal of 300 repository stars is secondary. Missing a star target with good retention can still justify continuing.
+
+Test two hooks: A, “Your coding agent can help you write a book”; B, “What if that idea became a chapter?” Use comparable clips and equal observation windows. Log impressions and attributed attempts where available. With very small samples, treat differences as leads to investigate, not statistical proof. After at least 10 attributable install attempts per hook, prioritize the one producing more successful chapter/resume journeys per attempt, while checking support burden. If both fail activation, fix onboarding rather than rewriting the headline again.
+
+Review weekly: which host attracts attempts, where users stop, which channel produces return users, and which content answers repeated questions. Keep two productive channels; pause channels that consume support time without bringing people who write. Start with no paid advertising. Consider a small, explicitly budgeted test only after activation and retention are observable.
+
+## The founder's next five actions
+
+1. Record one real chapter/resume demonstration on a host with verified access.
+2. Observe ten pilot attempts and publish the aggregate result, including failures.
+3. Post the founder story and demo with a single invitation to try a chapter.
+4. Turn the most common failure into the next product fix and public update.
+5. Expand the campaign after the evidence gate; let real author outcomes introduce the project.

--- a/marketing/agent-native/metrics.csv
+++ b/marketing/agent-native/metrics.csv
@@ -1,0 +1,2 @@
+week_start,channel,content_id,impressions,video_views,link_clicks,repo_visits,reported_install_attempts,first_chapter_saved,fresh_session_resume,activated_projects,eligible_for_7_day_return,returned_after_7_days,permitted_public_examples,stars_total,forks_total,support_minutes,notes
+,,,,,,,,,,,,,,,,,Blank values mean unknown; publish only aggregates and keep participant-level records private

--- a/marketing/agent-native/platform-copy.md
+++ b/marketing/agent-native/platform-copy.md
@@ -1,0 +1,151 @@
+# English platform drafts
+
+Drafts for human review. Repository URL: https://github.com/felipelobomotta-blip/book-genesis-v4
+
+Recheck the current release and compatibility table before posting. Attach a real demonstration only after recording it. These drafts do not claim that a book was completed in this release. Do not paste any of this text into Hacker News; that platform requires independently human-written posts and comments.
+
+## X: main announcement
+
+Your coding agent can help you write a book.
+
+I'm building Book Genesis: open-source writing skills for the agent you already use. DeepSeek Harness is now an install target too.
+
+Try one chapter. Tell me where it breaks.
+
+https://github.com/felipelobomotta-blip/book-genesis-v4
+
+## X: five-post thread
+
+1. I like coding and inventing things. I also have ideas that never become anything. Book Genesis is my attempt to help more of those ideas become books.
+
+2. I tried building a bigger app around the process. I ran into reliability and usability problems. I've brought the project back to writing skills inside the agents people already use.
+
+3. The workflow covers direction, outline, drafting, review, revision, and packaging. Your agent handles the model and tools. Book Genesis supplies the writing instructions and references.
+
+4. There are now 15 installation targets, including DeepSeek Harness, Cursor, Copilot, Qwen, and Pi. Installation tests are separate from real writing tests. The compatibility table says what we've checked.
+
+5. I'm looking for people willing to try a first chapter and give honest feedback. Bring an idea and an agent you already use.
+
+https://github.com/felipelobomotta-blip/book-genesis-v4
+
+## LinkedIn: founder story
+
+I want to make it easier for someone with an idea to start writing a book.
+
+I'm Felipe. I like coding and inventing things, and I'm building Book Genesis in public.
+
+I tried a broader app around the writing process. The reliability and usability problems made me rethink the direction. I've returned the project to a simpler foundation: writing skills that run inside the AI agents people already use.
+
+The latest update adds installation support for DeepSeek Harness, Cursor, GitHub Copilot, Qwen Code, Pi, and Windsurf. The same package guides an agent through the idea, outline, chapters, review, and revision. The files stay under the user's control, with the host's normal model and account rules.
+
+I care about making the creative starting point more accessible. I also want to be honest about what still needs work. A passing installation test doesn't prove that someone will finish a strong book. That's why the next milestone is observing people save a first chapter and continue it in a new session.
+
+If you already use an agent and have a book idea, I'd value a practical test. Try a chapter and tell me where you get stuck. I want to improve this with real feedback.
+
+The code and skills are MIT licensed:
+https://github.com/felipelobomotta-blip/book-genesis-v4
+
+## YouTube: walkthrough package
+
+Title A: Write a Book with Your AI Agent | Book Genesis Setup
+
+Title B: From a Book Idea to a Saved Chapter with Book Genesis
+
+Use title B only when the recording includes that completed journey. If recording intake only, use: “Start a Book Project with Book Genesis: Setup and Outline.”
+
+Description:
+
+Book Genesis is an open-source writing skills package for agents such as Claude Code, Codex, DeepSeek Harness, OpenCode, and others.
+
+This walkthrough shows the actual host, installation, writing artifacts, and recovery steps captured in the video. Read the compatibility table for what has been tested in each host. The package is MIT licensed; model usage depends on your host account and may have a cost or quota.
+
+Get the project: https://github.com/felipelobomotta-blip/book-genesis-v4
+Installation: https://github.com/felipelobomotta-blip/book-genesis-v4/blob/master/docs/portability.md
+Host evidence: https://github.com/felipelobomotta-blip/book-genesis-v4/blob/master/docs/compatibility.md
+
+Bring a book idea. Try one chapter. Tell me where the process needs work.
+
+Add chapter timestamps only after editing the actual recording. Add the tested commit, host/version, model if visible, elapsed generation time, and any cuts in the description.
+
+## Shorts, Reels, and TikTok
+
+Opening spoken line: “You already have an AI agent. What if you used it to work on that book idea?”
+
+Caption A: “I'm building Book Genesis: writing skills for the agent you already use. Bring an idea, try a chapter, and help me improve it. Open source. Setup and host evidence are in the repo.”
+
+Caption B, only after the shown recovery succeeds: “The part I wanted to show: closing the session, opening it again, and continuing from the saved project. Here's the actual attempt. Book Genesis is open source; I'd love feedback from people trying their first chapter.”
+
+Use two or three relevant tags, for example #OpenSource #CreativeWriting #AIAgents. Add a direct profile link where the platform supports it. Adapt the edit and caption for each platform; do not imply a clickable caption link if it is unavailable.
+
+## Eight-slide carousel copy
+
+1. Your creativity. Your agent. Your book.
+2. Start with the idea you keep putting off.
+3. Give the agent you already use a writing workflow.
+4. Develop the direction, outline, and chapters.
+5. Read critically. Find weaknesses. Revise.
+6. Save the files. Come back and continue. Show an actual recovery example here before publishing.
+7. Now with DeepSeek Harness and five more install targets. Check the host evidence table.
+8. Try one chapter. Help me improve Book Genesis. Open source on GitHub.
+
+Produce the visual carousel from real screenshots and simple typography. Do not invent application screens or label planned screenshots as captured output.
+
+## DEV: article outline
+
+Working title: “Teaching an existing AI agent a book-writing workflow”
+
+Open with the problem you observed: the writing process needs structure and persistent artifacts, while a separate app adds installation and model orchestration to maintain. Show the current package layout and a reproducible install. Explain the shared workflow, optional Python helper, active-phase loading, editorial gates, and saved-state contract. Include the compatibility table and a real attempt with its failure points. Finish with one concrete contribution request: reproduce a named host's chapter/resume journey. Disclose AI assistance as required by the publication's current policy; verify that policy before posting.
+
+## Reddit/community draft: adapt only after checking rules
+
+Suggested title: “I made an open-source writing workflow for the agent I already use”
+
+I'm the person building Book Genesis. It's a collection of skills and references that gives a file-aware agent a book-writing workflow: direction, outline, chapters, editorial review, and revision.
+
+I've added native skill-directory installers for several hosts, including DeepSeek Harness. The installer copies the same package; it doesn't start another model service or ask for API keys. Usage still depends on the host account.
+
+I'm looking for specific feedback on setup and continuing a project in a new session. The repository separates installation checks from actual native-agent observations. Complete-book reliability across every host is still something to establish.
+
+If this fits the community rules, the source and setup are here:
+https://github.com/felipelobomotta-blip/book-genesis-v4
+
+For an agent-specific community, replace the generic description with a real example captured in that host. If self-promotion is disallowed, do not post this draft or disguise it as an unrelated question.
+
+## Product Hunt draft
+
+Name: Book Genesis
+
+Tagline: Write your book with the AI agent you already use
+
+Description: Open-source writing skills for your existing AI agent. Develop an idea, outline chapters, draft, review, and revise in files you control. Includes 15 installation targets, such as Claude Code, Codex, DeepSeek Harness, Cursor, and Pi. MIT licensed; model access and usage depend on your host account.
+
+First maker comment:
+
+Hi, I'm Felipe, the person building Book Genesis.
+
+I like making things, and I wanted to help more people get beyond having a book idea. After trying a broader app, I returned the project to a portable skills package for the agents people already use.
+
+The goal is to provide a writing process people can inspect and improve: develop the idea, save the work, review it, and continue. The compatibility page distinguishes installer tests from native-host observations.
+
+I'd appreciate practical feedback from trying a first chapter. Which part made sense, and where did you get stuck?
+
+Before submitting: pass the launch gate, attach real screenshots, verify the direct repository URL, and add the completed walkthrough if available. Ask for product feedback. Do not ask for votes. Refer to the current [Product Hunt preparation guide](https://www.producthunt.com/launch/preparing-for-launch) for field limits and asset requirements.
+
+## Personalized creator invitation
+
+Use only when an individual has a relevant public submission/contact route, and replace the bracketed context with something you actually watched or read. No messages have been sent.
+
+“Hi [name], I'm Felipe. Your [specific public tutorial] helped me understand [actual detail]. I'm building Book Genesis, an open-source writing workflow that installs into existing agents. I thought it might fit the kind of practical experiments you show.
+
+Here's the repo and compatibility evidence: https://github.com/felipelobomotta-blip/book-genesis-v4
+
+If you try it, I'd welcome a critical look at the setup and first chapter. No obligation to cover it. Thanks for taking a look.”
+
+## Short replies to common questions
+
+- **Is it free?** The package is MIT licensed. Your agent's subscription, model usage, or local hardware can still have costs.
+- **Does it use my existing subscription?** It runs inside the host you choose. That host's supported login, model access, and quotas apply; the installer doesn't bypass them.
+- **Does it guarantee a bestseller?** No. It provides a structured process for drafting and improving a manuscript. Readers and sales require real-world evidence.
+- **Has every host written a complete book?** No. See the compatibility table for the difference between installation checks and native writing observations.
+- **Does it run locally?** The skills and project files can be local. Whether model requests leave your machine depends on the host and model you choose.
+- **Where did you get stuck?** Thank the person, ask for the host/version and reproducible steps, and request a sanitized error rather than credentials or a private manuscript.

--- a/runner/distribution.py
+++ b/runner/distribution.py
@@ -55,6 +55,8 @@ def resolve_install_root(
     environment = os.environ if environ is None else environ
     home_env = str(spec.get("home_env", ""))
     configured_home = environment.get(home_env, "") if home_env else ""
+    if spec.get("ignore_blank_home") and not configured_home.strip():
+        configured_home = ""
     xdg_home = environment.get("XDG_CONFIG_HOME", "")
     if configured_home:
         runtime_home = Path(configured_home).expanduser() / str(spec.get("configured_home_subdir", ""))
@@ -150,7 +152,11 @@ def validate_suite() -> dict[str, object]:
     if not evaluator_protocol.exists():
         errors.append("independent evaluator protocol is missing")
 
-    required_targets = {"claude", "codex", "kimi", "openclaw", "hermes", "shared", "opencode", "antigravity", "gemini"}
+    required_targets = {
+        "claude", "codex", "kimi", "openclaw", "hermes", "shared",
+        "opencode", "antigravity", "gemini", "deepseek", "cursor",
+        "copilot", "qwen", "pi", "windsurf",
+    }
     target_names = set(supported_targets())
     missing_targets = sorted(required_targets - target_names)
     if missing_targets:

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -77,6 +77,42 @@ class DistributionTests(unittest.TestCase):
                     target, destination=explicit, environ={variable: str(custom)}))
                 self.assertFalse(home.exists())
 
+    def test_additional_host_default_directories(self) -> None:
+        home = self.tempdir / "home"
+        for target, folder in {
+            "deepseek": ".dsh", "cursor": ".cursor", "copilot": ".copilot",
+            "qwen": ".qwen", "pi": ".pi/agent", "windsurf": ".codeium/windsurf",
+        }.items():
+            with self.subTest(target=target):
+                self.assertEqual((home / folder / "skills").resolve(),
+                                 resolve_install_root(target, home=home, environ={}))
+                explicit = self.tempdir / "project skills"
+                self.assertEqual(explicit.resolve(), resolve_install_root(
+                    target, home=home, destination=explicit, environ={}))
+        self.assertFalse(home.exists())
+
+    def test_deepseek_and_pi_custom_home_directories(self) -> None:
+        for target, variable in (("deepseek", "DSH_HOME"), ("pi", "PI_CODING_AGENT_DIR")):
+            with self.subTest(target=target):
+                custom = self.tempdir / "custom agent home"
+                self.assertEqual((custom / "skills").resolve(), resolve_install_root(
+                    target, environ={variable: str(custom)}))
+                explicit = self.tempdir / "workspace skills"
+                self.assertEqual(explicit.resolve(), resolve_install_root(
+                    target, destination=explicit, environ={variable: str(custom)}))
+
+    def test_deepseek_blank_home_matches_native_default(self) -> None:
+        home = self.tempdir / "home"
+        for value in ("", "   ", "\t "):
+            with self.subTest(value=value):
+                self.assertEqual((home / ".dsh/skills").resolve(), resolve_install_root(
+                    "deepseek", home=home, environ={"DSH_HOME": value}))
+
+    def test_copilot_additional_search_paths_are_not_a_home_directory(self) -> None:
+        home = self.tempdir / "home"
+        self.assertEqual((home / ".copilot/skills").resolve(), resolve_install_root(
+            "copilot", home=home, environ={"COPILOT_SKILLS_DIRS": "one,two"}))
+
     def test_new_targets_cli_install_reinstall_and_reference_integrity(self) -> None:
         for target in supported_targets():
             with self.subTest(target=target):
@@ -88,6 +124,8 @@ class DistributionTests(unittest.TestCase):
                 self.assertFalse(destination.exists())
                 installed = subprocess.run(command, capture_output=True, text=True)
                 self.assertEqual(0, installed.returncode, installed.stdout + installed.stderr)
+                verified = verify_install(target, destination=destination)
+                self.assertTrue(verified["ok"], msg=str(verified["errors"]))
                 for source in (REPO_ROOT / "skills/book-genesis").rglob("*"):
                     if source.is_file():
                         copied = destination / "book-genesis" / source.relative_to(REPO_ROOT / "skills/book-genesis")


### PR DESCRIPTION
## What changes

People using DeepSeek Harness, Cursor, GitHub Copilot, Qwen Code, Pi, or Windsurf can now install the same complete writing-skills bundle into their native skill directories. This brings the installer to 15 targets: 14 named hosts plus Shared. DeepSeek respects DSH_HOME, including its native blank-value fallback; Pi respects PI_CODING_AGENT_DIR. The Python installer, PowerShell wrapper, shell wrapper, and CI target lists agree.

The English README and host guides explain setup, official discovery conventions, custom directories, and the distinction between installation verification and real native writing. A new launch kit includes positioning, a 30-day calendar, platform drafts, actual-demo recording scripts, evidence gates, and aggregate metrics templates. It records no social posts, completed videos, or native book runs that did not happen.

## Validation

- 41 local regression tests pass, including actual installation, reference/checksum verification, and reinstall across all 15 targets.
- PowerShell previews pass for all targets; suite contract validation passes.
- New regressions cover six default directories, custom homes, destination precedence, DeepSeek blank home, and Copilot's additional-path-list boundary.
- Marketing local links, JSON, 30-row calendar, CSV columns, and copy length bounds checked.
- Windows/Linux/macOS CI on Python 3.10 and 3.12 runs on this pull request.

## Limits

The six new integrations are source/documentation-verified installation targets. Fresh native writing and complete-book acceptance in those hosts remain open. Existing native observations are preserved separately. No model runner, credential configuration, or global user installation is added.
