### PR TITLE
Docs: finish the 5.0 installer transition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Book Genesis accepts improvements to editorial contracts, portable skills, deter
 ```bash
 git clone https://github.com/felipelobomotta-blip/book-genesis-v4.git
 cd book-genesis-v4
-python runner/cli.py verify-suite
+python runner/installer.py verify-suite
 python -m unittest discover -s tests -v
 ```
 
@@ -28,7 +28,7 @@ No provider API key is needed for repository tests. Runner never calls a model.
 - Keep `SKILL.md` concise and put detailed contracts under `references/`.
 - Preserve `name` and `description` frontmatter.
 - Add referenced specialist skills to `distribution/portable-suite.json`.
-- Run `python runner/cli.py verify-suite` after changing manifests, registries, prompts, or skill packaging.
+- Run `python runner/installer.py verify-suite` after changing manifests, registries, prompts, or skill packaging.
 
 ## Runner Changes
 

--- a/agents/book-orchestrator.md
+++ b/agents/book-orchestrator.md
@@ -1,12 +1,14 @@
 ---
 name: book-orchestrator
-description: Fully autonomous book genesis pipeline. Takes a one-line idea and produces a publish-ready manuscript. Dispatches specialized agents for each phase, manages state, enforces quality gates, tracks entities via ENTITY_STATE.yaml. Only pauses for human approval at 3 checkpoints. Never writes prose.
+description: Legacy Book Genesis V4 orchestrator retained for historical reference. Not installed by the 5.0 portable skills bundle.
 tools: Read, Write, Edit, Grep, Glob, Bash, Agent, WebSearch
 model: opus
 maxTurns: 200
 ---
 
-# BOOK GENESIS V4 — Autonomous Orchestrator
+# BOOK GENESIS V4 — Legacy Orchestrator Reference
+
+> This file is retained for historical comparison. Book Genesis 5.0 installs the portable `book-genesis` skill and does not install or promise this autonomous V4 runner.
 
 You are a fully autonomous book creation pipeline. You receive an idea and you PRODUCE A BOOK. You dispatch specialized agents, manage state files, enforce quality gates, and advance through all phases WITHOUT waiting for human input — except at 3 explicit checkpoints.
 

--- a/docs/book-genesis-codex.md
+++ b/docs/book-genesis-codex.md
@@ -17,17 +17,17 @@ skills/book-genesis/
     legacy-v4-book-genesis.md
 ```
 
-The optional local runner lives at:
+The maintainer-only installer/verifier lives at:
 
 ```text
 runner/
-  cli.py
+  installer.py
   filesystem.py
 tests/
   test_runner.py
 ```
 
-The runner scaffolds projects, prepares phase packets, validates required files, advances gates, prepares optional Book Swarm Panel/MiroFish bridge folders, and writes specialist agent packets for Book Bestseller Studio. It does not call a model or generate real prose.
+The installer copies skills, validates references, and records installation integrity. It does not call a model, scaffold a project, advance gates, or generate prose. The historical runner implementation remains in Git history but is not part of the 5.0 product surface.
 
 The folder `book-genesis-codex` is historical and preserved for compatibility. New installs use `book-genesis`: **Book Genesis is a universal book pipeline for AI agents.**
 
@@ -146,10 +146,8 @@ Use Book Genesis. Read AGENTS.md, then run the manifest in skills/book-genesis/r
 For a local mechanical check:
 
 ```bash
-python runner/cli.py demo .tmp-book-genesis-demo
-python runner/cli.py validate .tmp-book-genesis-demo
-python runner/cli.py prepare-swarm .tmp-book-genesis-demo --mode hybrid --slug launch-reaction
-python runner/cli.py prepare-agent-packet .tmp-book-genesis-demo pacing_engineer
+python runner/installer.py verify-suite
+python runner/installer.py install shared --dry-run
 ```
 
 For an existing manuscript:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -31,10 +31,10 @@ A subsequent write-recovery attempt encountered a host-denied terminal command. 
 ## Check your installation
 
 ```bash
-python runner/cli.py verify-suite
-python runner/cli.py install opencode --dry-run
-python runner/cli.py install opencode
-python runner/cli.py verify-install opencode
+python runner/installer.py verify-suite
+python runner/installer.py install opencode --dry-run
+python runner/installer.py install opencode
+python runner/installer.py verify-install opencode
 opencode debug skill
 ```
 

--- a/marketing/agent-native/demo-scripts.md
+++ b/marketing/agent-native/demo-scripts.md
@@ -17,9 +17,9 @@ Capture the real commands, selecting the tested target:
 ```bash
 git clone https://github.com/felipelobomotta-blip/book-genesis-v4.git
 cd book-genesis-v4
-python runner/cli.py verify-suite
-python runner/cli.py install deepseek
-python runner/cli.py verify-install deepseek
+python runner/installer.py verify-suite
+python runner/installer.py install deepseek
+python runner/installer.py verify-install deepseek
 ```
 
 The example names DeepSeek because it is the new integration; it must be exercised natively before using DeepSeek footage or claiming a successful writing run. Select another verified host for the first recording if necessary. The installer cannot prove native writing by itself.


### PR DESCRIPTION
Replace the last stale runner/cli.py commands with runner/installer.py, mark the V4 orchestrator and runner docs as historical, and keep the 5.0 product boundary consistent. Validation: installer verify-suite; 40 Python tests; git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup, compatibility, usage, and demonstration instructions to use the current installation and verification workflow.
  * Clarified that the legacy Book Genesis V4 orchestrator is retained for historical reference and is not included in the portable 5.0 skills bundle.
  * Documented the maintainer-only installer’s supported responsibilities, including skill installation, reference validation, and integrity tracking.
  * Clarified that historical project scaffolding and orchestration workflows are no longer part of the 5.0 product surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->